### PR TITLE
feat(#169 matches/Realtime): Подготовка протокола для ECS

### DIFF
--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/DeleteFieldIncomeByObjectCommandCollector.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/DeleteFieldIncomeByObjectCommandCollector.cs
@@ -12,7 +12,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         {
             this.id = id;
             router = client.GetPlugin<DeleteFieldCommandRouterByObjec>();
-            router.RegisterListener(ref id, fieldId, OnChange);
+            router.RegisterListener(in id, fieldId, OnChange);
         }
 
 
@@ -27,7 +27,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         public override void Dispose()
         {
             base.Dispose();
-            router.UnRegisterListener(ref id, fieldId, OnChange);
+            router.UnRegisterListener(in id, fieldId, OnChange);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/DoubleIncomeByObjectCommandCollector.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/DoubleIncomeByObjectCommandCollector.cs
@@ -12,7 +12,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         {
             this.id = id;
             router = client.GetPlugin<DoubleCommandRouterByObject>();
-            router.RegisterListener(ref id, fieldId, OnChange);
+            router.RegisterListener(in id, fieldId, OnChange);
         }
 
 
@@ -27,7 +27,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         public override void Dispose()
         {
             base.Dispose();
-            router.UnRegisterListener(ref id, fieldId, OnChange);
+            router.UnRegisterListener(in id, fieldId, OnChange);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/EventIncomeByObjectCommandCollector.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/EventIncomeByObjectCommandCollector.cs
@@ -14,7 +14,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         {
             this.id = id;
             router = client.GetPlugin<EventCommandRouterByObject>();
-            router.RegisterListener(ref id, fieldId, OnEvent);
+            router.RegisterListener(in id, fieldId, OnEvent);
             codec = client.CodecRegistry.GetCodec<T>();
         }
 
@@ -31,7 +31,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         public override void Dispose()
         {
             base.Dispose();
-            router.UnRegisterListener(ref id, fieldId, OnEvent);
+            router.UnRegisterListener(in id, fieldId, OnEvent);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/LongIncomeByObjectCommandCollector.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/LongIncomeByObjectCommandCollector.cs
@@ -12,7 +12,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         {
             this.id = id;
             router = client.GetPlugin<LongCommandRouterByObject>();
-            router.RegisterListener(ref id, fieldId, OnChange);
+            router.RegisterListener(in id, fieldId, OnChange);
         }
 
 
@@ -27,7 +27,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         public override void Dispose()
         {
             base.Dispose();
-            router.UnRegisterListener(ref id, fieldId, OnChange);
+            router.UnRegisterListener(in id, fieldId, OnChange);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/StructureIncomeByObjectCommandCollector.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime.doa/Runtime/Income/ByObject/StructureIncomeByObjectCommandCollector.cs
@@ -14,7 +14,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         {
             this.id = id;
             router = client.GetPlugin<StructureCommandRouterByObject>();
-            router.RegisterListener(ref id, fieldId, OnStructure);
+            router.RegisterListener(in id, fieldId, OnStructure);
             codec = client.CodecRegistry.GetCodec<T>();
         }
 
@@ -31,7 +31,7 @@ namespace Cheetah.Matches.Realtime.DOA.Income.ByObject
         public override void Dispose()
         {
             base.Dispose();
-            router.UnRegisterListener(ref id, fieldId, OnStructure);
+            router.UnRegisterListener(in id, fieldId, OnStructure);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/CheetahObject.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/CheetahObject.cs
@@ -1,6 +1,5 @@
 using System;
 using Cheetah.Matches.Realtime.Internal;
-using Cheetah.Matches.Realtime.Internal.FFI;
 using Cheetah.Matches.Realtime.Types;
 
 namespace Cheetah.Matches.Realtime
@@ -24,99 +23,62 @@ namespace Cheetah.Matches.Realtime
 
         public void SetStructure<T>(ushort fieldId, ref T item)
         {
-            buffer.Clear();
-            Client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
-            ResultChecker.Check(StructureFFI.Set(Client.Id, ref ObjectId, fieldId, ref buffer));
+            Client.SetStructure(in ObjectId, ref buffer, fieldId, in item);
         }
 
         public void CompareAndSetStructure<T>(ushort fieldId, ref T current, ref T newval)
         {
-            buffer.Clear();
-            var newBuffer = new CheetahBuffer();
-            var resetBuffer = new CheetahBuffer();
-            var codec = Client.CodecRegistry.GetCodec<T>();
-            codec.Encode(in current, ref buffer);
-            codec.Encode(in newval, ref newBuffer);
-
-            ResultChecker.Check(StructureFFI.CompareAndSet(
-                Client.Id,
-                ref ObjectId,
-                fieldId,
-                ref buffer,
-                ref newBuffer,
-                false,
-                ref resetBuffer
-            ));
+            Client.CompareAndSetStructure(in ObjectId, ref buffer, fieldId, in current, in newval);
         }
 
         public void CompareAndSetStructureWithReset<T>(ushort fieldId, ref T current, ref T newval, ref T reset)
         {
-            buffer.Clear();
-            var newBuffer = new CheetahBuffer();
-            var resetBuffer = new CheetahBuffer();
-            var codec = Client.CodecRegistry.GetCodec<T>();
-            codec.Encode(in current, ref buffer);
-            codec.Encode(in newval, ref newBuffer);
-            codec.Encode(in reset, ref resetBuffer);
-
-            ResultChecker.Check(StructureFFI.CompareAndSet(
-                Client.Id,
-                ref ObjectId,
-                fieldId,
-                ref buffer,
-                ref newBuffer,
-                true,
-                ref resetBuffer
-            ));
+            Client.CompareAndSetStructureWithReset(in ObjectId, ref buffer, fieldId, in current, in newval, in reset);
         }
 
         public void SendEvent<T>(ushort eventId, ref T item)
         {
-            buffer.Clear();
-            Client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
-            ResultChecker.Check(EventFFI.Send(Client.Id, ref ObjectId, eventId, ref buffer));
+            Client.SendEvent(in ObjectId, ref buffer, eventId, in item);
         }
 
         public void SendEvent<T>(ushort eventId, uint targetUser, ref T item)
         {
-            buffer.Clear();
-            Client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
-            ResultChecker.Check(EventFFI.Send(Client.Id, (ushort)targetUser, ref ObjectId, eventId, ref buffer));
+            Client.SendEvent(in ObjectId, ref buffer, eventId, targetUser, in item);
         }
 
         public void SetLong(ushort fieldId, long value)
         {
-            ResultChecker.Check(LongFFI.Set(Client.Id, ref ObjectId, fieldId, value));
+            Client.SetLong(in ObjectId, fieldId, value);
         }
 
         public void IncrementLong(ushort fieldId, long increment)
         {
-            ResultChecker.Check(LongFFI.Increment(Client.Id, ref ObjectId, fieldId, increment));
+            Client.IncrementLong(in ObjectId, fieldId, increment);
         }
 
         public void CompareAndSetLong(ushort fieldId, long currentValue, long newValue)
         {
-            ResultChecker.Check(LongFFI.CompareAndSet(Client.Id, ref ObjectId, fieldId, currentValue, newValue, false, 0));
+            Client.CompareAndSetLong(in ObjectId, fieldId, currentValue, newValue);
         }
 
         public void CompareAndSetLongWithReset(ushort fieldId, long currentValue, long newValue, long resetValue)
         {
-            ResultChecker.Check(LongFFI.CompareAndSet(Client.Id, ref ObjectId, fieldId, currentValue, newValue, true, resetValue));
+            Client.CompareAndSetLongWithReset(in ObjectId, fieldId, currentValue, newValue, resetValue);
         }
 
         public void SetDouble(ushort fieldId, double value)
         {
-            ResultChecker.Check(DoubleFFI.Set(Client.Id, ref ObjectId, fieldId, value));
+            Client.SetDouble(in ObjectId, fieldId, value);
         }
 
         public void DeleteField(ushort fieldId, FieldType fieldType)
         {
-            ResultChecker.Check(FieldFFI.Delete(Client.Id, ref ObjectId, fieldId, fieldType));
+            Client.DeleteField(in ObjectId, fieldId, fieldType);
         }
 
         public void IncrementDouble(ushort fieldId, double increment)
         {
-            ResultChecker.Check(DoubleFFI.Increment(Client.Id, ref ObjectId, fieldId, increment));
+            Client.IncrementDouble(in ObjectId, fieldId, increment);
         }
 
         /// <summary>
@@ -124,7 +86,7 @@ namespace Cheetah.Matches.Realtime
         /// </summary>
         public void Delete()
         {
-            ResultChecker.Check(ObjectFFI.Delete(Client.Id, ref ObjectId));
+            Client.Delete(in ObjectId);
         }
 
         public override string ToString()

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/CheetahObjectsCreateInfo.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/CheetahObjectsCreateInfo.cs
@@ -23,40 +23,40 @@ namespace Cheetah.Matches.Realtime.Internal
             router.ObjectPostDeleteListener += OnDeleted;
         }
 
-        private void OnObjectCreating(ref CheetahObjectId objectId, ushort template)
+        private void OnObjectCreating(in CheetahObjectId objectId, ushort template)
         {
             templates.Add(objectId, template);
         }
 
-        private void OnObjectCreated(ref CheetahObjectId objectId)
+        private void OnObjectCreated(in CheetahObjectId objectId)
         {
             created.Add(objectId);
         }
 
-        private void OnDeleted(ref CheetahObjectId objectId)
+        private void OnDeleted(in CheetahObjectId objectId)
         {
             templates.Remove(objectId);
             created.Remove(objectId);
         }
 
-        public CheetahObject GetObject(ref CheetahObjectId objectId)
+        public CheetahObject GetObject(in CheetahObjectId objectId)
         {
             return new CheetahObject(objectId, templates[objectId], client);
         }
 
-        public bool IsCreated(ref CheetahObjectId objectId)
+        public bool IsCreated(in CheetahObjectId objectId)
         {
             return created.Contains(objectId);
         }
 
-        public void OnLocalObjectCreating(ref CheetahObjectId objectId, ushort template)
+        public void OnLocalObjectCreating(in CheetahObjectId objectId, ushort template)
         {
-            OnObjectCreating(ref objectId, template);
+            OnObjectCreating(in objectId, template);
         }
 
-        public void OnLocalObjectCreate(ref CheetahObjectId objectId)
+        public void OnLocalObjectCreate(in CheetahObjectId objectId)
         {
-            OnObjectCreated(ref objectId);
+            OnObjectCreated(in objectId);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/DoubleFFI.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/DoubleFFI.cs
@@ -6,15 +6,15 @@ namespace Cheetah.Matches.Realtime.Internal.FFI
     internal static class DoubleFFI
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void Listener(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, double value);
+        public delegate void Listener(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, double value);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_double_value_listener")]
         public static extern byte SetListener(ushort clientId, Listener listener);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_double_value")]
-        public static extern byte Set(ushort clientId, ref CheetahObjectId objectId, ushort fieldId, double value);
+        public static extern byte Set(ushort clientId, in CheetahObjectId objectId, ushort fieldId, double value);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "inc_double_value")]
-        public static extern byte Increment(ushort clientId, ref CheetahObjectId objectId, ushort fieldId, double increment);
+        public static extern byte Increment(ushort clientId, in CheetahObjectId objectId, ushort fieldId, double increment);
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/EventFFI.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/EventFFI.cs
@@ -6,15 +6,15 @@ namespace Cheetah.Matches.Realtime.Internal.FFI
     internal static class EventFFI
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void Listener(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
+        public delegate void Listener(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_event_listener")]
         public static extern byte SetListener(ushort clientId, Listener listener);
         
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "send_event")]
-        public static extern byte Send(ushort clientId, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
+        public static extern byte Send(ushort clientId, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "send_target_event")]
-        public static extern byte Send(ushort clientId, ushort targetUser, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
+        public static extern byte Send(ushort clientId, ushort targetUser, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/FieldFFI.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/FieldFFI.cs
@@ -6,12 +6,12 @@ namespace Cheetah.Matches.Realtime.Internal.FFI
     internal static class FieldFFI
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void Listener(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, FieldType fieldType);
+        public delegate void Listener(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, FieldType fieldType);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_delete_field_listener")]
         public static extern byte SetListener(ushort clientId, Listener listener);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "delete_field")]
-        public static extern byte Delete(ushort clientId, ref CheetahObjectId objectId, ushort fieldId, FieldType value);
+        public static extern byte Delete(ushort clientId, in CheetahObjectId objectId, ushort fieldId, FieldType value);
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/LongFFI.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/LongFFI.cs
@@ -6,19 +6,19 @@ namespace Cheetah.Matches.Realtime.Internal.FFI
     internal static class LongFFI
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void Listener(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, long value);
+        public delegate void Listener(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, long value);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_long_value_listener")]
         public static extern byte SetListener(ushort clientId, Listener listener);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_long_value")]
-        public static extern byte Set(ushort clientId, ref CheetahObjectId objectId, ushort fieldId, long value);
+        public static extern byte Set(ushort clientId, in CheetahObjectId objectId, ushort fieldId, long value);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "inc_long_value")]
-        public static extern byte Increment(ushort clientId, ref CheetahObjectId objectId, ushort fieldId, long increment);
+        public static extern byte Increment(ushort clientId, in CheetahObjectId objectId, ushort fieldId, long increment);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "compare_and_set_long_value")]
-        public static extern byte CompareAndSet(ushort clientId, ref CheetahObjectId objectId, ushort fieldId, long currentValue, long newValue,
+        public static extern byte CompareAndSet(ushort clientId, in CheetahObjectId objectId, ushort fieldId, long currentValue, long newValue,
             bool hasReset, long resetValue);
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/ObjectFFI.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/ObjectFFI.cs
@@ -6,10 +6,10 @@ namespace Cheetah.Matches.Realtime.Internal.FFI
     internal static class ObjectFFI
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void CreateListener(ref CheetahObjectId objectId, ushort template);
+        public delegate void CreateListener(in CheetahObjectId objectId, ushort template);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void CreatedListener(ref CheetahObjectId objectId);
+        public delegate void CreatedListener(in CheetahObjectId objectId);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_create_object_listener")]
         public static extern byte SetCreateListener(ushort clientId, CreateListener listener);
@@ -22,17 +22,17 @@ namespace Cheetah.Matches.Realtime.Internal.FFI
         public static extern byte CreateObject(ushort clientId, ushort template, ulong accessGroup, ref CheetahObjectId objectId);
         
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "created_object")]
-        public static extern byte Created(ushort clientId, ref CheetahObjectId objectId, bool roomOwner, ref CheetahBuffer singletonKey);
+        public static extern byte Created(ushort clientId, in CheetahObjectId objectId, bool roomOwner, ref CheetahBuffer singletonKey);
 
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void DeleteListener(ref CheetahObjectId objectId);
+        public delegate void DeleteListener(in CheetahObjectId objectId);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_delete_object_listener")]
         public static extern byte SetDeleteListener(ushort clientId, DeleteListener objectDeleteListener);
 
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "delete_object")]
-        public static extern byte Delete(ushort clientId, ref CheetahObjectId objectId);
+        public static extern byte Delete(ushort clientId, in CheetahObjectId objectId);
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/StructureFFI.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/FFI/StructureFFI.cs
@@ -6,18 +6,18 @@ namespace Cheetah.Matches.Realtime.Internal.FFI
     internal class StructureFFI
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void Listener(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
+        public delegate void Listener(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_structure_listener")]
         public static extern byte SetListener(ushort clientId, Listener listener);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "set_structure")]
-        public static extern byte Set(ushort clientId, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
+        public static extern byte Set(ushort clientId, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data);
 
         [DllImport(Const.Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "compare_and_set_structure")]
         public static extern byte CompareAndSet(
             ushort clientId,
-            ref CheetahObjectId objectId,
+            in CheetahObjectId objectId,
             ushort fieldId,
             ref CheetahBuffer currentValue,
             ref CheetahBuffer newValue,

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/CheetahObjectConstructorCollector.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/CheetahObjectConstructorCollector.cs
@@ -46,7 +46,7 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin
             client.GetPlugin<DoubleCommandRouter>().ChangeListener += OnDoubleChange;
         }
 
-        private void OnObjectDelete(ref CheetahObjectId objectId)
+        private void OnObjectDelete(in CheetahObjectId objectId)
         {
             creatingObjects.Remove(objectId);
         }
@@ -70,14 +70,14 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin
             }
         }
 
-        private void OnObjectCreating(ref CheetahObjectId objectId, ushort template)
+        private void OnObjectCreating(in CheetahObjectId objectId, ushort template)
         {
-            var cheetahObject = cheetahObjectsCreateInfo.GetObject(ref objectId);
+            var cheetahObject = cheetahObjectsCreateInfo.GetObject(in objectId);
             creatingObjects.Add(objectId, new CheetahObjectConstructor(cheetahObject, client.CodecRegistry));
         }
 
 
-        private void OnStructChange(ushort creator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
+        private void OnStructChange(ushort creator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
         {
             if (creatingObjects.TryGetValue(objectId, out var creatingObject))
             {
@@ -85,7 +85,7 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin
             }
         }
 
-        private void OnDoubleChange(ushort creator, ref CheetahObjectId objectId, ushort fieldId, double value)
+        private void OnDoubleChange(ushort creator, in CheetahObjectId objectId, ushort fieldId, double value)
         {
             if (creatingObjects.TryGetValue(objectId, out var creatingObject))
             {
@@ -93,7 +93,7 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin
             }
         }
 
-        private void OnLongChange(ushort creator, ref CheetahObjectId objectId, ushort fieldId, long value)
+        private void OnLongChange(ushort creator, in CheetahObjectId objectId, ushort fieldId, long value)
         {
             if (creatingObjects.TryGetValue(objectId, out var creatingObject))
             {
@@ -106,9 +106,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin
         /// Объект создан - вызываем подписчиков
         /// </summary>
         /// <param name="objectId"></param>
-        private void OnObjectCreated(ref CheetahObjectId objectId)
+        private void OnObjectCreated(in CheetahObjectId objectId)
         {
-            var cheetahObject = cheetahObjectsCreateInfo.GetObject(ref objectId);
+            var cheetahObject = cheetahObjectsCreateInfo.GetObject(in objectId);
             if (createdListeners.TryGetValue(cheetahObject.Template, out var listeners))
             {
                 if (creatingObjects.TryGetValue(objectId, out var createdObject))

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/AbstractRouterByField.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/AbstractRouterByField.cs
@@ -49,11 +49,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByField
             }
         }
 
-        protected void Notify(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref T data)
+        protected void Notify(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref T data)
         {
             if (listenersByFieldId.TryGetValue(fieldId, out var listeners))
             {
-                listeners.Notify(commandCreator, createInfo.GetObject(ref objectId), createInfo.IsCreated(ref objectId), ref data);
+                listeners.Notify(commandCreator, createInfo.GetObject(in objectId), createInfo.IsCreated(in objectId), ref data);
             }
         }
     }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/DoubleCommandRouterByField.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/DoubleCommandRouterByField.cs
@@ -14,9 +14,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByField
             doubleCommandRouter.ChangeListener += OnChange;
         }
 
-        private void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, double value)
+        private void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, double value)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref value);
+            Notify(commandCreator, in objectId, fieldId, ref value);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/EventCommandRouterByField.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/EventCommandRouterByField.cs
@@ -15,9 +15,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByField
         }
 
 
-        private void OnNewEvent(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
+        private void OnNewEvent(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref data);
+            Notify(commandCreator, in objectId, fieldId, ref data);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/LongCommandRouterByField.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/LongCommandRouterByField.cs
@@ -14,9 +14,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByField
             doubleCommandRouter.ChangeListener += OnChange;
         }
 
-        private void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, long value)
+        private void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, long value)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref value);
+            Notify(commandCreator, in objectId, fieldId, ref value);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/StructCommandRouterByField.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByField/StructCommandRouterByField.cs
@@ -15,9 +15,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByField
         }
 
 
-        private void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
+        private void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref data);
+            Notify(commandCreator, in objectId, fieldId, ref data);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/AbstractRouterByObject.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/AbstractRouterByObject.cs
@@ -54,7 +54,7 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByObjectId
             createInfo = client.GetPlugin<CheetahObjectsCreateInfo>();
         }
 
-        public void RegisterListener(ref CheetahObjectId id, ushort fieldId, Listener listener)
+        public void RegisterListener(in CheetahObjectId id, ushort fieldId, Listener listener)
         {
             var key = CreateKey(id, fieldId);
             if (!listenersByFieldId.TryGetValue(key, out var listeners))
@@ -76,7 +76,7 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByObjectId
         }
 
 
-        public void UnRegisterListener(ref CheetahObjectId id, ushort fieldId, Listener listener)
+        public void UnRegisterListener(in CheetahObjectId id, ushort fieldId, Listener listener)
         {
             if (listenersByFieldId.TryGetValue(CreateKey(id, fieldId), out var listeners))
             {
@@ -84,11 +84,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByObjectId
             }
         }
 
-        protected void Notify(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref T data)
+        protected void Notify(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref T data)
         {
             if (listenersByFieldId.TryGetValue(CreateKey(objectId, fieldId), out var listeners))
             {
-                listeners.Notify(commandCreator, createInfo.GetObject(ref objectId), createInfo.IsCreated(ref objectId), ref data);
+                listeners.Notify(commandCreator, createInfo.GetObject(in objectId), createInfo.IsCreated(in objectId), ref data);
             }
         }
     }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/DeleteFieldCommandRouterByObject.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/DeleteFieldCommandRouterByObject.cs
@@ -14,9 +14,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByObjectId
             router.DeleteListener += OnDelete;
         }
 
-        private void OnDelete(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, FieldType fieldType)
+        private void OnDelete(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, FieldType fieldType)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref fieldType);
+            Notify(commandCreator, in objectId, fieldId, ref fieldType);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/DoubleCommandRouterByObject.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/DoubleCommandRouterByObject.cs
@@ -14,9 +14,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByObjectId
             doubleCommandRouter.ChangeListener += OnChange;
         }
 
-        private void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, double value)
+        private void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, double value)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref value);
+            Notify(commandCreator, in objectId, fieldId, ref value);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/EventCommandRouterByObject.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/EventCommandRouterByObject.cs
@@ -14,9 +14,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByObjectId
             eventCommandRouter.NewEventListener += OnChange;
         }
 
-        private void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer value)
+        private void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer value)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref value);
+            Notify(commandCreator, in objectId, fieldId, ref value);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/LongCommandRouterByObject.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/LongCommandRouterByObject.cs
@@ -14,9 +14,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByObjectId
             longCommandRouter.ChangeListener += OnChange;
         }
 
-        private void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, long value)
+        private void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, long value)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref value);
+            Notify(commandCreator, in objectId, fieldId, ref value);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/StructureCommandRouterByObject.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByObjectId/StructureCommandRouterByObject.cs
@@ -14,9 +14,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByObjectId
             structCommandRouter.ChangeListener += OnChange;
         }
 
-        private void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer value)
+        private void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer value)
         {
-            Notify(commandCreator, ref objectId, fieldId, ref value);
+            Notify(commandCreator, in objectId, fieldId, ref value);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/Abstract/AbstractObjectEventRouterByTemplate.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/Abstract/AbstractObjectEventRouterByTemplate.cs
@@ -5,9 +5,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByTemplate.Abstract
     public class AbstractObjectEventRouterByTemplate : AbstractRouterByTemplate<CheetahObject>
     {
         
-        protected void Notify(ref CheetahObjectId objectId)
+        protected void Notify(in CheetahObjectId objectId)
         {
-            var cheetahObject = objectsCreateInfo.GetObject(ref objectId);
+            var cheetahObject = objectsCreateInfo.GetObject(in objectId);
             if (listenersByTemplate.TryGetValue(cheetahObject.Template, out var listeners))
             {
                 listeners.Notify(cheetahObject);

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/CreatedObjectRouterByTemplate.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/CreatedObjectRouterByTemplate.cs
@@ -18,9 +18,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByTemplate
             objectCommandRouter.ObjectCreatedListener += OnObjectCreated;
         }
 
-        private void OnObjectCreated(ref CheetahObjectId objectId)
+        private void OnObjectCreated(in CheetahObjectId objectId)
         {
-            Notify(ref objectId);
+            Notify(in objectId);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/CreatingObjectRouterByTemplate.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/CreatingObjectRouterByTemplate.cs
@@ -18,9 +18,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByTemplate
             objectCommandRouter.ObjectCreatingListener += OnObjectCreating;
         }
 
-        private void OnObjectCreating(ref CheetahObjectId objectId, ushort template)
+        private void OnObjectCreating(in CheetahObjectId objectId, ushort template)
         {
-            Notify(ref objectId);
+            Notify(in objectId);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/DeleteFieldRouterByTemplate.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/DeleteFieldRouterByTemplate.cs
@@ -15,9 +15,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByTemplate
             router.DeleteListener += OnFieldDelete;
         }
 
-        private void OnFieldDelete(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, FieldType fieldType)
+        private void OnFieldDelete(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, FieldType fieldType)
         {
-            var cheetahObject = objectsCreateInfo.GetObject(ref objectId);
+            var cheetahObject = objectsCreateInfo.GetObject(in objectId);
             if (listenersByTemplate.TryGetValue(cheetahObject.Template, out var listeners))
             {
                 listeners.Notify(new DeletedField

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/DeleteObjectRouterByTemplate.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/ByTemplate/DeleteObjectRouterByTemplate.cs
@@ -15,9 +15,9 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.ByTemplate
             objectCommandRouter.ObjectDeleteListener += OnObjectDelete;
         }
 
-        private void OnObjectDelete(ref CheetahObjectId objectId)
+        private void OnObjectDelete(in CheetahObjectId objectId)
         {
-            Notify(ref objectId);
+            Notify(in objectId);
         }
     }
 }

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/DeleteFieldCommandRouter.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/DeleteFieldCommandRouter.cs
@@ -24,11 +24,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.FFI
         }
 
         [MonoPInvokeCallback(typeof(FieldFFI.Listener))]
-        private static void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, FieldType fieldType)
+        private static void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, FieldType fieldType)
         {
             try
             {
-                current.DeleteListener?.Invoke(commandCreator, ref objectId, fieldId, fieldType);
+                current.DeleteListener?.Invoke(commandCreator, in objectId, fieldId, fieldType);
             }
             catch (Exception e)
             {

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/DoubleCommandRouter.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/DoubleCommandRouter.cs
@@ -24,11 +24,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.FFI
         }
 
         [MonoPInvokeCallback(typeof(DoubleFFI.Listener))]
-        private static void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, double value)
+        private static void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, double value)
         {
             try
             {
-                current.ChangeListener?.Invoke(commandCreator, ref objectId, fieldId, value);
+                current.ChangeListener?.Invoke(commandCreator, in objectId, fieldId, value);
             }
             catch (Exception e)
             {

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/EventCommandRouter.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/EventCommandRouter.cs
@@ -24,11 +24,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.FFI
         }
 
         [MonoPInvokeCallback(typeof(EventFFI.Listener))]
-        private static void OnEvent(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
+        private static void OnEvent(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
         {
             try
             {
-                current.NewEventListener?.Invoke(commandCreator, ref objectId, fieldId, ref data);
+                current.NewEventListener?.Invoke(commandCreator, in objectId, fieldId, ref data);
             }
             catch (Exception e)
             {

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/LongCommandRouter.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/LongCommandRouter.cs
@@ -24,11 +24,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.FFI
         }
 
         [MonoPInvokeCallback(typeof(LongFFI.Listener))]
-        private static void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, long value)
+        private static void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, long value)
         {
             try
             {
-                current.ChangeListener?.Invoke(commandCreator, ref objectId, fieldId, value);
+                current.ChangeListener?.Invoke(commandCreator, in objectId, fieldId, value);
             }
             catch (Exception e)
             {

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/ObjectCommandRouter.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/ObjectCommandRouter.cs
@@ -33,11 +33,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.FFI
         }
 
         [MonoPInvokeCallback(typeof(ObjectFFI.CreateListener))]
-        private static void OnCreateListener(ref CheetahObjectId objectId, ushort template)
+        private static void OnCreateListener(in CheetahObjectId objectId, ushort template)
         {
             try
             {
-                current.ObjectCreatingListener?.Invoke(ref objectId, template);
+                current.ObjectCreatingListener?.Invoke(in objectId, template);
             }
             catch (Exception e)
             {
@@ -46,11 +46,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.FFI
         }
 
         [MonoPInvokeCallback(typeof(ObjectFFI.CreatedListener))]
-        private static void OnCreatedListener(ref CheetahObjectId objectId)
+        private static void OnCreatedListener(in CheetahObjectId objectId)
         {
             try
             {
-                current.ObjectCreatedListener?.Invoke(ref objectId);
+                current.ObjectCreatedListener?.Invoke(in objectId);
             }
             catch (Exception e)
             {
@@ -60,12 +60,12 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.FFI
 
 
         [MonoPInvokeCallback(typeof(ObjectFFI.DeleteListener))]
-        private static void OnDeleteListener(ref CheetahObjectId objectId)
+        private static void OnDeleteListener(in CheetahObjectId objectId)
         {
             try
             {
-                current.ObjectDeleteListener?.Invoke(ref objectId);
-                current.ObjectPostDeleteListener?.Invoke(ref objectId);
+                current.ObjectDeleteListener?.Invoke(in objectId);
+                current.ObjectPostDeleteListener?.Invoke(in objectId);
             }
             catch (Exception e)
             {

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/StructCommandRouter.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Plugin/Routers/FFI/StructCommandRouter.cs
@@ -24,11 +24,11 @@ namespace Cheetah.Matches.Realtime.Internal.Plugin.Routers.FFI
         }
 
         [MonoPInvokeCallback(typeof(StructureFFI.Listener))]
-        private static void OnChange(ushort commandCreator, ref CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
+        private static void OnChange(ushort commandCreator, in CheetahObjectId objectId, ushort fieldId, ref CheetahBuffer data)
         {
             try
             {
-                current.ChangeListener?.Invoke(commandCreator, ref objectId, fieldId, ref data);
+                current.ChangeListener?.Invoke(commandCreator, in objectId, fieldId, ref data);
             }
             catch (Exception e)
             {

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Protocol.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Protocol.cs
@@ -1,0 +1,127 @@
+using Cheetah.Matches.Realtime.Internal.FFI;
+using Cheetah.Matches.Realtime.Types;
+
+namespace Cheetah.Matches.Realtime.Internal
+{
+    public static class Protocol
+    {
+        public static void SetStructure<T>(this CheetahClient client, in CheetahObjectId objectId,
+            ref CheetahBuffer buffer, ushort fieldId, in T item)
+        {
+            buffer.Clear();
+            client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
+            ResultChecker.Check(StructureFFI.Set(client.Id, in objectId, fieldId, ref buffer));
+        }
+
+        public static void CompareAndSetStructure<T>(this CheetahClient client, in CheetahObjectId objectId,
+            ref CheetahBuffer buffer, ushort fieldId, in T current, in T newval)
+        {
+            buffer.Clear();
+            var newBuffer = new CheetahBuffer();
+            var resetBuffer = new CheetahBuffer();
+            var codec = client.CodecRegistry.GetCodec<T>();
+            codec.Encode(in current, ref buffer);
+            codec.Encode(in newval, ref newBuffer);
+
+            ResultChecker.Check(StructureFFI.CompareAndSet(
+                client.Id,
+                in objectId,
+                fieldId,
+                ref buffer,
+                ref newBuffer,
+                false,
+                ref resetBuffer
+            ));
+        }
+
+        public static void CompareAndSetStructureWithReset<T>(this CheetahClient client, in CheetahObjectId objectId,
+            ref CheetahBuffer buffer, ushort fieldId, in T current, in T newval, in T reset)
+        {
+            buffer.Clear();
+            var newBuffer = new CheetahBuffer();
+            var resetBuffer = new CheetahBuffer();
+            var codec = client.CodecRegistry.GetCodec<T>();
+            codec.Encode(in current, ref buffer);
+            codec.Encode(in newval, ref newBuffer);
+            codec.Encode(in reset, ref resetBuffer);
+
+            ResultChecker.Check(StructureFFI.CompareAndSet(
+                client.Id,
+                in objectId,
+                fieldId,
+                ref buffer,
+                ref newBuffer,
+                true,
+                ref resetBuffer
+            ));
+        }
+
+        public static void SendEvent<T>(this CheetahClient client, in CheetahObjectId objectId,
+            ref CheetahBuffer buffer, ushort eventId, in T item)
+        {
+            buffer.Clear();
+            client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
+            ResultChecker.Check(EventFFI.Send(client.Id, in objectId, eventId, ref buffer));
+        }
+
+        public static void SendEvent<T>(this CheetahClient client, in CheetahObjectId objectId,
+            ref CheetahBuffer buffer, ushort eventId, uint targetUser, in T item)
+        {
+            buffer.Clear();
+            client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
+            ResultChecker.Check(EventFFI.Send(client.Id, (ushort) targetUser, in objectId, eventId, ref buffer));
+        }
+
+        public static void SetLong(this CheetahClient client, in CheetahObjectId objectId,
+            ushort fieldId, long value)
+        {
+            ResultChecker.Check(LongFFI.Set(client.Id, in objectId, fieldId, value));
+        }
+
+        public static void IncrementLong(this CheetahClient client, in CheetahObjectId objectId,
+            ushort fieldId, long increment)
+        {
+            ResultChecker.Check(LongFFI.Increment(client.Id, in objectId, fieldId, increment));
+        }
+
+        public static void CompareAndSetLong(this CheetahClient client, in CheetahObjectId objectId,
+            ushort fieldId, long currentValue, long newValue)
+        {
+            ResultChecker.Check(
+                LongFFI.CompareAndSet(client.Id, in objectId, fieldId, currentValue, newValue, false, 0));
+        }
+
+        public static void CompareAndSetLongWithReset(this CheetahClient client, in CheetahObjectId objectId,
+            ushort fieldId, long currentValue, long newValue, long resetValue)
+        {
+            ResultChecker.Check(LongFFI.CompareAndSet(client.Id, in objectId, fieldId, currentValue, newValue, true,
+                resetValue));
+        }
+
+        public static void SetDouble(this CheetahClient client, in CheetahObjectId objectId,
+            ushort fieldId, double value)
+        {
+            ResultChecker.Check(DoubleFFI.Set(client.Id, in objectId, fieldId, value));
+        }
+
+        public static void DeleteField(this CheetahClient client, in CheetahObjectId objectId,
+            ushort fieldId, FieldType fieldType)
+        {
+            ResultChecker.Check(FieldFFI.Delete(client.Id, in objectId, fieldId, fieldType));
+        }
+
+        public static void IncrementDouble(this CheetahClient client, in CheetahObjectId objectId,
+            ushort fieldId, double increment)
+        {
+            ResultChecker.Check(DoubleFFI.Increment(client.Id, in objectId, fieldId, increment));
+        }
+
+        /// <summary>
+        /// Удалить игровой объект на сервере
+        /// </summary>
+        public static void Delete(this CheetahClient client, in CheetahObjectId objectId)
+        {
+            ResultChecker.Check(ObjectFFI.Delete(client.Id, in objectId));
+        }
+    }
+}

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Protocol.cs.meta
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/Protocol.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a4e935f1a9ea4d8eb1e9801733930dda
+timeCreated: 1663584121

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Types/CheetahObjectBuilder.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Types/CheetahObjectBuilder.cs
@@ -27,9 +27,9 @@ namespace Cheetah.Matches.Realtime.Types
         public CheetahObject Build()
         {
             buffer.Clear();
-            ResultChecker.Check(ObjectFFI.Created(client.Id, ref objectId, false, ref buffer));
-            createdInfo.OnLocalObjectCreating(ref objectId, template);
-            createdInfo.OnLocalObjectCreate(ref objectId);
+            ResultChecker.Check(ObjectFFI.Created(client.Id, in objectId, false, ref buffer));
+            createdInfo.OnLocalObjectCreating(in objectId, template);
+            createdInfo.OnLocalObjectCreate(in objectId);
             return new CheetahObject(objectId, template, client);
         }
 
@@ -39,7 +39,7 @@ namespace Cheetah.Matches.Realtime.Types
         public void BuildRoomObject()
         {
             buffer.Clear();
-            ResultChecker.Check(ObjectFFI.Created(client.Id, ref objectId, true, ref buffer));
+            ResultChecker.Check(ObjectFFI.Created(client.Id, in objectId, true, ref buffer));
         }
 
         /// <summary>
@@ -50,12 +50,12 @@ namespace Cheetah.Matches.Realtime.Types
         {
             buffer.Clear();
             client.CodecRegistry.GetCodec<T>().Encode(in singletonKey, ref buffer);
-            ResultChecker.Check(ObjectFFI.Created(client.Id, ref objectId, true, ref buffer));
+            ResultChecker.Check(ObjectFFI.Created(client.Id, in objectId, true, ref buffer));
         }
 
         public CheetahObjectBuilder SetDouble(ushort fieldId, double value)
         {
-            ResultChecker.Check(DoubleFFI.Set(client.Id, ref objectId, fieldId, value));
+            ResultChecker.Check(DoubleFFI.Set(client.Id, in objectId, fieldId, value));
             return this;
         }
 
@@ -63,25 +63,25 @@ namespace Cheetah.Matches.Realtime.Types
         {
             buffer.Clear();
             client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
-            ResultChecker.Check(StructureFFI.Set(client.Id, ref objectId, fieldId, ref buffer));
+            ResultChecker.Check(StructureFFI.Set(client.Id, in objectId, fieldId, ref buffer));
             return this;
         }
 
         public CheetahObjectBuilder SetLong(ushort fieldId, long value)
         {
-            ResultChecker.Check(LongFFI.Set(client.Id, ref objectId, fieldId, value));
+            ResultChecker.Check(LongFFI.Set(client.Id, in objectId, fieldId, value));
             return this;
         }
 
         public CheetahObjectBuilder CompareAndSetLong(ushort fieldId, long currentValue, long newValue)
         {
-            ResultChecker.Check(LongFFI.CompareAndSet(client.Id, ref objectId, fieldId, currentValue, newValue, false, 0));
+            ResultChecker.Check(LongFFI.CompareAndSet(client.Id, in objectId, fieldId, currentValue, newValue, false, 0));
             return this;
         }
 
         public CheetahObjectBuilder CompareAndSetLongWithReset(ushort fieldId, long currentValue, long newValue, long resetValue)
         {
-            ResultChecker.Check(LongFFI.CompareAndSet(client.Id, ref objectId, fieldId, currentValue, newValue, true, resetValue));
+            ResultChecker.Check(LongFFI.CompareAndSet(client.Id, in objectId, fieldId, currentValue, newValue, true, resetValue));
             return this;
         }
 
@@ -96,7 +96,7 @@ namespace Cheetah.Matches.Realtime.Types
 
             ResultChecker.Check(StructureFFI.CompareAndSet(
                 client.Id,
-                ref objectId,
+                in objectId,
                 fieldId,
                 ref buffer,
                 ref newBuffer,
@@ -119,7 +119,7 @@ namespace Cheetah.Matches.Realtime.Types
 
             ResultChecker.Check(StructureFFI.CompareAndSet(
                 client.Id,
-                ref objectId,
+                in objectId,
                 fieldId,
                 ref buffer,
                 ref newBuffer,


### PR DESCRIPTION
- Ивзлек логику протокола из CheetahObject
- Поменял для аргументов протокола `ref` на `in`

теперь из Unity ECS можно будет использовать `OnChangeFilter` при записи изменений компонентов и иметь value type компонент с `CheetahObjectId` вместо  reference type CheetahObject