### PR TITLE
Выделить логику записи в протокол

### DIFF
--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/CheetahObject.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/CheetahObject.cs
@@ -1,6 +1,5 @@
 using System;
 using Cheetah.Matches.Realtime.Internal;
-using Cheetah.Matches.Realtime.Internal.FFI;
 using Cheetah.Matches.Realtime.Types;
 
 namespace Cheetah.Matches.Realtime
@@ -24,99 +23,62 @@ namespace Cheetah.Matches.Realtime
 
         public void SetStructure<T>(ushort fieldId, ref T item)
         {
-            buffer.Clear();
-            Client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
-            ResultChecker.Check(StructureFFI.Set(Client.Id, in ObjectId, fieldId, ref buffer));
+            Client.SetStructure(ref buffer, in ObjectId, fieldId, in item);
         }
 
         public void CompareAndSetStructure<T>(ushort fieldId, ref T current, ref T newval)
         {
-            buffer.Clear();
-            var newBuffer = new CheetahBuffer();
-            var resetBuffer = new CheetahBuffer();
-            var codec = Client.CodecRegistry.GetCodec<T>();
-            codec.Encode(in current, ref buffer);
-            codec.Encode(in newval, ref newBuffer);
-
-            ResultChecker.Check(StructureFFI.CompareAndSet(
-                Client.Id,
-                in ObjectId,
-                fieldId,
-                ref buffer,
-                ref newBuffer,
-                false,
-                ref resetBuffer
-            ));
+            Client.CompareAndSetStructure(ref buffer, in ObjectId, fieldId, in current, in newval);
         }
 
         public void CompareAndSetStructureWithReset<T>(ushort fieldId, ref T current, ref T newval, ref T reset)
         {
-            buffer.Clear();
-            var newBuffer = new CheetahBuffer();
-            var resetBuffer = new CheetahBuffer();
-            var codec = Client.CodecRegistry.GetCodec<T>();
-            codec.Encode(in current, ref buffer);
-            codec.Encode(in newval, ref newBuffer);
-            codec.Encode(in reset, ref resetBuffer);
-
-            ResultChecker.Check(StructureFFI.CompareAndSet(
-                Client.Id,
-                in ObjectId,
-                fieldId,
-                ref buffer,
-                ref newBuffer,
-                true,
-                ref resetBuffer
-            ));
+            Client.CompareAndSetStructureWithReset(ref buffer, in ObjectId, fieldId, in current, in newval, in reset);
         }
 
         public void SendEvent<T>(ushort eventId, ref T item)
         {
-            buffer.Clear();
-            Client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
-            ResultChecker.Check(EventFFI.Send(Client.Id, in ObjectId, eventId, ref buffer));
+            Client.SendEvent(ref buffer, in ObjectId, eventId, in item);
         }
 
         public void SendEvent<T>(ushort eventId, uint targetUser, ref T item)
         {
-            buffer.Clear();
-            Client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
-            ResultChecker.Check(EventFFI.Send(Client.Id, (ushort)targetUser, in ObjectId, eventId, ref buffer));
+            Client.SendEvent(ref buffer, in ObjectId, eventId, targetUser, in item);
         }
 
         public void SetLong(ushort fieldId, long value)
         {
-            ResultChecker.Check(LongFFI.Set(Client.Id, in ObjectId, fieldId, value));
+            Client.SetLong(in ObjectId, fieldId, value);
         }
 
         public void IncrementLong(ushort fieldId, long increment)
         {
-            ResultChecker.Check(LongFFI.Increment(Client.Id, in ObjectId, fieldId, increment));
+            Client.IncrementLong(in ObjectId, fieldId, increment);
         }
 
         public void CompareAndSetLong(ushort fieldId, long currentValue, long newValue)
         {
-            ResultChecker.Check(LongFFI.CompareAndSet(Client.Id, in ObjectId, fieldId, currentValue, newValue, false, 0));
+            Client.CompareAndSetLong(in ObjectId, fieldId, currentValue, newValue);
         }
 
         public void CompareAndSetLongWithReset(ushort fieldId, long currentValue, long newValue, long resetValue)
         {
-            ResultChecker.Check(LongFFI.CompareAndSet(Client.Id, in ObjectId, fieldId, currentValue, newValue, true, resetValue));
+            Client.CompareAndSetLongWithReset(in ObjectId, fieldId, currentValue, newValue, resetValue);
         }
 
         public void SetDouble(ushort fieldId, double value)
         {
-            ResultChecker.Check(DoubleFFI.Set(Client.Id, in ObjectId, fieldId, value));
+            Client.SetDouble(in ObjectId, fieldId, value);
         }
 
         public void DeleteField(ushort fieldId, FieldType fieldType)
         {
-            ResultChecker.Check(FieldFFI.Delete(Client.Id, in ObjectId, fieldId, fieldType));
+            Client.DeleteField(in ObjectId, fieldId, fieldType);
         }
 
         public void IncrementDouble(ushort fieldId, double increment)
         {
-            ResultChecker.Check(DoubleFFI.Increment(Client.Id, in ObjectId, fieldId, increment));
+            Client.IncrementDouble(in ObjectId, fieldId, increment);
         }
 
         /// <summary>
@@ -124,7 +86,7 @@ namespace Cheetah.Matches.Realtime
         /// </summary>
         public void Delete()
         {
-            ResultChecker.Check(ObjectFFI.Delete(Client.Id, in ObjectId));
+            Client.Delete(in ObjectId);
         }
 
         public override string ToString()

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/ProtocolExtensions.cs
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/ProtocolExtensions.cs
@@ -1,0 +1,121 @@
+using Cheetah.Matches.Realtime.Internal.FFI;
+using Cheetah.Matches.Realtime.Types;
+
+namespace Cheetah.Matches.Realtime.Internal
+{
+    public static class ProtocolExtensions
+    {
+        public static void SetStructure<T>(this CheetahClient client, ref CheetahBuffer buffer,
+            in CheetahObjectId objectId, ushort fieldId, in T item)
+        {
+            buffer.Clear();
+            client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
+            ResultChecker.Check(StructureFFI.Set(client.Id, in objectId, fieldId, ref buffer));
+        }
+
+        public static void CompareAndSetStructure<T>(this CheetahClient client, ref CheetahBuffer buffer,
+            in CheetahObjectId objectId, ushort fieldId, in T current, in T newval)
+        {
+            buffer.Clear();
+            var newBuffer = new CheetahBuffer();
+            var resetBuffer = new CheetahBuffer();
+            var codec = client.CodecRegistry.GetCodec<T>();
+            codec.Encode(in current, ref buffer);
+            codec.Encode(in newval, ref newBuffer);
+
+            ResultChecker.Check(StructureFFI.CompareAndSet(
+                client.Id,
+                in objectId,
+                fieldId,
+                ref buffer,
+                ref newBuffer,
+                false,
+                ref resetBuffer
+            ));
+        }
+
+        public static void CompareAndSetStructureWithReset<T>(this CheetahClient client, ref CheetahBuffer buffer,
+            in CheetahObjectId objectId, ushort fieldId, in T current, in T newval, in T reset)
+        {
+            buffer.Clear();
+            var newBuffer = new CheetahBuffer();
+            var resetBuffer = new CheetahBuffer();
+            var codec = client.CodecRegistry.GetCodec<T>();
+            codec.Encode(in current, ref buffer);
+            codec.Encode(in newval, ref newBuffer);
+            codec.Encode(in reset, ref resetBuffer);
+
+            ResultChecker.Check(StructureFFI.CompareAndSet(
+                client.Id,
+                in objectId,
+                fieldId,
+                ref buffer,
+                ref newBuffer,
+                true,
+                ref resetBuffer
+            ));
+        }
+
+        public static void SendEvent<T>(this CheetahClient client, ref CheetahBuffer buffer,
+            in CheetahObjectId objectId, ushort eventId, in T item)
+        {
+            buffer.Clear();
+            client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
+            ResultChecker.Check(EventFFI.Send(client.Id, in objectId, eventId, ref buffer));
+        }
+
+        public static void SendEvent<T>(this CheetahClient client, ref CheetahBuffer buffer,
+            in CheetahObjectId objectId, ushort eventId, uint targetUser, in T item)
+        {
+            buffer.Clear();
+            client.CodecRegistry.GetCodec<T>().Encode(in item, ref buffer);
+            ResultChecker.Check(EventFFI.Send(client.Id, (ushort)targetUser, in objectId, eventId, ref buffer));
+        }
+
+        public static void SetLong(this CheetahClient client, in CheetahObjectId objectId, ushort fieldId, long value)
+        {
+            ResultChecker.Check(LongFFI.Set(client.Id, in objectId, fieldId, value));
+        }
+
+        public static void IncrementLong(this CheetahClient client, in CheetahObjectId objectId, ushort fieldId,
+            long increment)
+        {
+            ResultChecker.Check(LongFFI.Increment(client.Id, in objectId, fieldId, increment));
+        }
+
+        public static void CompareAndSetLong(this CheetahClient client, in CheetahObjectId objectId, ushort fieldId,
+            long currentValue, long newValue)
+        {
+            ResultChecker.Check(LongFFI.CompareAndSet(client.Id, in objectId, fieldId, currentValue, newValue, false, 0));
+        }
+
+        public static void CompareAndSetLongWithReset(this CheetahClient client, in CheetahObjectId objectId,
+            ushort fieldId, long currentValue, long newValue, long resetValue)
+        {
+            ResultChecker.Check(LongFFI.CompareAndSet(client.Id, in objectId, fieldId, currentValue, newValue, true, resetValue));
+        }
+
+        public static void SetDouble(this CheetahClient client, in CheetahObjectId objectId, ushort fieldId,
+            double value)
+        {
+            ResultChecker.Check(DoubleFFI.Set(client.Id, in objectId, fieldId, value));
+        }
+
+        public static void DeleteField(this CheetahClient client, in CheetahObjectId objectId, ushort fieldId,
+            FieldType fieldType)
+        {
+            ResultChecker.Check(FieldFFI.Delete(client.Id, in objectId, fieldId, fieldType));
+        }
+
+        public static void IncrementDouble(this CheetahClient client, in CheetahObjectId objectId, ushort fieldId,
+            double increment)
+        {
+            ResultChecker.Check(DoubleFFI.Increment(client.Id, in objectId, fieldId, increment));
+        }
+
+        public static void Delete(this CheetahClient client, in CheetahObjectId objectId)
+        {
+            ResultChecker.Check(ObjectFFI.Delete(client.Id, in objectId));
+        }
+    }
+}

--- a/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/ProtocolExtensions.cs.meta
+++ b/modules/matches/Realtime/client/Unity/games.cheetah.matches.realtime/Runtime/Internal/ProtocolExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e83f03cd12804a09bbdf556439b6fca9
+timeCreated: 1663743371


### PR DESCRIPTION
Выделил логику записи из `CheetahObject` в `ProtocolExtensions`, чтобы ее можно было использовать в других реализациях протокола