### PR TITLE
feat(#120 server/realtime): move Field to common

### DIFF
--- a/modules/matches/Realtime/client/rust/Realtime/src/clients/application_thread.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/src/clients/application_thread.rs
@@ -4,10 +4,10 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 use cheetah_matches_realtime_common::commands::types::create::CreateGameObjectCommand;
 use cheetah_matches_realtime_common::commands::FieldValue;
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::network::client::ConnectionStatus;
 use cheetah_matches_realtime_common::protocol::frame::applications::{BothDirectionCommand, ChannelGroup, CommandWithChannel};
 use cheetah_matches_realtime_common::protocol::frame::channel::ChannelType;

--- a/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/event.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/event.rs
@@ -1,6 +1,6 @@
 use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::types::event::{EventCommand, TargetEventCommand};
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::clients::registry::ClientId;

--- a/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/field.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/field.rs
@@ -1,6 +1,6 @@
 use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::types::field::DeleteFieldCommand;
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::clients::registry::ClientId;

--- a/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/float_value.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/float_value.rs
@@ -1,7 +1,7 @@
 use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::types::field::SetFieldCommand;
 use cheetah_matches_realtime_common::commands::types::float::IncrementDoubleC2SCommand;
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::clients::registry::ClientId;

--- a/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/long_value.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/long_value.rs
@@ -1,7 +1,7 @@
 use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::types::field::SetFieldCommand;
 use cheetah_matches_realtime_common::commands::types::long::{CompareAndSetLongCommand, IncrementLongC2SCommand};
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::clients::registry::ClientId;

--- a/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/structure.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/src/ffi/command/structure.rs
@@ -1,8 +1,8 @@
 use cheetah_matches_realtime_common::commands::binary_value::BinaryValue;
 use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::types::field::SetFieldCommand;
 use cheetah_matches_realtime_common::commands::types::structure::CompareAndSetStructureCommand;
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::clients::registry::ClientId;

--- a/modules/matches/Realtime/client/rust/Realtime/tests/cmd_event.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/cmd_event.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 
 use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::{BufferFFI, GameObjectIdFFI};
-use cheetah_matches_realtime_common::constants::FieldId;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::setup;

--- a/modules/matches/Realtime/client/rust/Realtime/tests/cmd_field.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/cmd_field.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 
 use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::{FieldTypeFFI, GameObjectIdFFI};
-use cheetah_matches_realtime_common::constants::FieldId;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::setup;
@@ -23,7 +23,7 @@ fn should_delete_field_ffi() {
 	helper.wait_udp();
 	ffi::client::receive(client2);
 
-	assert!(matches!(DELETED_FIELD.lock().unwrap().as_ref(),Option::Some((field_id, field_type)) if 
+	assert!(matches!(DELETED_FIELD.lock().unwrap().as_ref(),Option::Some((field_id, field_type)) if
 			*field_id ==1 && *field_type==FieldTypeFFI::Long ));
 }
 

--- a/modules/matches/Realtime/client/rust/Realtime/tests/cmd_float.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/cmd_float.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 
 use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::GameObjectIdFFI;
-use cheetah_matches_realtime_common::constants::FieldId;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::setup;
@@ -24,7 +24,7 @@ fn should_inc() {
 	helper.wait_udp();
 	ffi::client::receive(client2);
 
-	assert!(matches!(INCR.lock().unwrap().as_ref(),Option::Some((field_id, value)) if *field_id 
+	assert!(matches!(INCR.lock().unwrap().as_ref(),Option::Some((field_id, value)) if *field_id
 		== 1 && (*value - 200.0).abs() < 0.001 ));
 }
 

--- a/modules/matches/Realtime/client/rust/Realtime/tests/cmd_long.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/cmd_long.rs
@@ -6,8 +6,8 @@ use lazy_static::lazy_static;
 use cheetah_matches_realtime::room::template::config::Permission;
 use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::GameObjectIdFFI;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::FieldType;
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::setup;

--- a/modules/matches/Realtime/client/rust/Realtime/tests/cmd_member_object.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/cmd_member_object.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 
 use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::{BufferFFI, GameObjectIdFFI};
-use cheetah_matches_realtime_common::constants::FieldId;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::setup;

--- a/modules/matches/Realtime/client/rust/Realtime/tests/cmd_structure.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/cmd_structure.rs
@@ -4,8 +4,8 @@ use std::sync::Mutex;
 use cheetah_matches_realtime::room::template::config::Permission;
 use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::{BufferFFI, GameObjectIdFFI};
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::FieldType;
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::setup;

--- a/modules/matches/Realtime/client/rust/Realtime/tests/cmd_target_event.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/cmd_target_event.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 
 use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::{BufferFFI, GameObjectIdFFI};
-use cheetah_matches_realtime_common::constants::FieldId;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::IntegrationTestHelper;

--- a/modules/matches/Realtime/client/rust/Realtime/tests/emulation.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/emulation.rs
@@ -6,7 +6,7 @@ use lazy_static::lazy_static;
 use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::channel::Channel;
 use cheetah_matches_realtime_client::ffi::GameObjectIdFFI;
-use cheetah_matches_realtime_common::constants::FieldId;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::setup;

--- a/modules/matches/Realtime/client/rust/Realtime/tests/helpers/server.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/helpers/server.rs
@@ -1,12 +1,13 @@
 use std::net::SocketAddr;
 
-use cheetah_matches_realtime::room::object::Field;
 use cheetah_matches_realtime::room::template::config::{
 	GameObjectTemplatePermission, GroupsPermissionRule, Permission, PermissionField, RoomTemplate,
 };
 use cheetah_matches_realtime::server::manager::RoomsServerManager;
+use cheetah_matches_realtime_common::commands::field::Field;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::FieldType;
-use cheetah_matches_realtime_common::constants::{FieldId, GameObjectTemplateId};
+use cheetah_matches_realtime_common::constants::GameObjectTemplateId;
 use cheetah_matches_realtime_common::network::bind_to_free_socket;
 use cheetah_matches_realtime_common::room::access::AccessGroups;
 use cheetah_matches_realtime_common::room::RoomId;

--- a/modules/matches/Realtime/client/rust/Realtime/tests/stress.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/stress.rs
@@ -8,7 +8,7 @@ use cheetah_matches_realtime_client::ffi;
 use cheetah_matches_realtime_client::ffi::channel::Channel;
 use cheetah_matches_realtime_client::ffi::logs::{init_logger, set_max_log_level, LogLevel};
 use cheetah_matches_realtime_client::ffi::GameObjectIdFFI;
-use cheetah_matches_realtime_common::constants::FieldId;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::helpers::helper::setup;

--- a/modules/matches/Realtime/common/Common/src/commands/c2s.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/c2s.rs
@@ -2,6 +2,7 @@ use std::io::Cursor;
 
 use strum_macros::AsRefStr;
 
+use crate::commands::field::FieldId;
 use crate::commands::types::create::{C2SCreatedGameObjectCommand, CreateGameObjectCommand};
 use crate::commands::types::delete::DeleteGameObjectCommand;
 use crate::commands::types::event::{EventCommand, TargetEventCommand};
@@ -10,7 +11,6 @@ use crate::commands::types::float::IncrementDoubleC2SCommand;
 use crate::commands::types::long::{CompareAndSetLongCommand, IncrementLongC2SCommand};
 use crate::commands::types::structure::CompareAndSetStructureCommand;
 use crate::commands::{CommandDecodeError, CommandTypeId, FieldType, FieldValue};
-use crate::constants::FieldId;
 use crate::protocol::codec::commands::context::CommandContextError;
 use crate::room::object::GameObjectId;
 
@@ -164,6 +164,7 @@ mod tests {
 
 	use crate::commands::binary_value::BinaryValue;
 	use crate::commands::c2s::C2SCommand;
+	use crate::commands::field::FieldId;
 	use crate::commands::types::create::{C2SCreatedGameObjectCommand, CreateGameObjectCommand};
 	use crate::commands::types::delete::DeleteGameObjectCommand;
 	use crate::commands::types::event::{EventCommand, TargetEventCommand};
@@ -172,7 +173,6 @@ mod tests {
 	use crate::commands::types::long::{CompareAndSetLongCommand, IncrementLongC2SCommand};
 	use crate::commands::types::structure::CompareAndSetStructureCommand;
 	use crate::commands::CommandTypeId;
-	use crate::constants::FieldId;
 	use crate::protocol::codec::commands::context::CommandContextError;
 	use crate::room::access::AccessGroups;
 	use crate::room::object::GameObjectId;

--- a/modules/matches/Realtime/common/Common/src/commands/field.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/field.rs
@@ -80,3 +80,11 @@ impl ToFieldType for &[u8] {
 		FieldType::Structure
 	}
 }
+
+pub type FieldId = u16;
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub struct Field {
+	pub id: FieldId,
+	pub field_type: FieldType,
+}

--- a/modules/matches/Realtime/common/Common/src/commands/field_value.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/field_value.rs
@@ -7,7 +7,7 @@ use crate::{
 	protocol::codec::variable_int::{VariableIntReader, VariableIntWriter},
 };
 
-use super::{binary_value::BinaryValue, field_type::ToFieldType};
+use super::{binary_value::BinaryValue, field::ToFieldType};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FieldValue {

--- a/modules/matches/Realtime/common/Common/src/commands/mod.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/mod.rs
@@ -4,12 +4,12 @@ use crate::protocol::codec::commands::context::CommandContextError;
 
 pub mod binary_value;
 pub mod c2s;
-pub mod field_type;
+pub mod field;
 mod field_value;
 pub mod s2c;
 pub mod types;
 
-pub use crate::commands::field_type::FieldType;
+pub use crate::commands::field::FieldType;
 pub use crate::commands::field_value::FieldValue;
 
 ///

--- a/modules/matches/Realtime/common/Common/src/commands/s2c.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/s2c.rs
@@ -1,12 +1,12 @@
 use std::io::Cursor;
 
+use crate::commands::field::FieldId;
 use crate::commands::field_value::FieldValue;
 use crate::commands::types::create::{CreateGameObjectCommand, GameObjectCreatedS2CCommand};
 use crate::commands::types::delete::DeleteGameObjectCommand;
 use crate::commands::types::event::EventCommand;
 use crate::commands::types::field::{DeleteFieldCommand, SetFieldCommand};
 use crate::commands::{CommandDecodeError, CommandTypeId, FieldType};
-use crate::constants::FieldId;
 use crate::protocol::codec::commands::context::CommandContextError;
 use crate::room::object::GameObjectId;
 use crate::room::RoomMemberId;
@@ -118,11 +118,11 @@ mod tests {
 	use std::io::Cursor;
 
 	use crate::commands::binary_value::BinaryValue;
+	use crate::commands::field::FieldId;
 	use crate::commands::types::create::{CreateGameObjectCommand, GameObjectCreatedS2CCommand};
 	use crate::commands::types::delete::DeleteGameObjectCommand;
 	use crate::commands::types::field::SetFieldCommand;
 	use crate::commands::CommandTypeId;
-	use crate::constants::FieldId;
 	use crate::{
 		commands::s2c::S2CCommand, commands::types::event::EventCommand, protocol::codec::commands::context::CommandContextError,
 		room::access::AccessGroups, room::object::GameObjectId, room::owner::GameObjectOwner,

--- a/modules/matches/Realtime/common/Common/src/commands/types/event.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/event.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use crate::commands::binary_value::BinaryValue;
-use crate::constants::FieldId;
+use crate::commands::field::FieldId;
 use crate::protocol::codec::variable_int::{VariableIntReader, VariableIntWriter};
 use crate::room::object::GameObjectId;
 use crate::room::RoomMemberId;

--- a/modules/matches/Realtime/common/Common/src/commands/types/field.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/field.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
-use crate::commands::{field_type::ToFieldType, FieldType, FieldValue};
-use crate::constants::FieldId;
+use crate::commands::field::FieldId;
+use crate::commands::{field::ToFieldType, FieldType, FieldValue};
 use crate::room::object::GameObjectId;
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/modules/matches/Realtime/common/Common/src/commands/types/float.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/float.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
-use crate::constants::FieldId;
+use crate::commands::field::FieldId;
 use crate::room::object::GameObjectId;
 
 ///

--- a/modules/matches/Realtime/common/Common/src/commands/types/long.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/long.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use crate::constants::FieldId;
+use crate::commands::field::FieldId;
 use crate::protocol::codec::variable_int::{VariableIntReader, VariableIntWriter};
 use crate::room::object::GameObjectId;
 
@@ -20,7 +20,7 @@ pub struct IncrementLongC2SCommand {
 ///
 /// Установка значения new если текущее равно current
 /// reset - значение после выхода пользователя
-///  
+///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompareAndSetLongCommand {
 	pub object_id: GameObjectId,

--- a/modules/matches/Realtime/common/Common/src/commands/types/structure.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/structure.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
 use crate::commands::binary_value::BinaryValue;
-use crate::constants::FieldId;
+use crate::commands::field::FieldId;
 use crate::room::object::GameObjectId;
 
 ///

--- a/modules/matches/Realtime/common/Common/src/constants.rs
+++ b/modules/matches/Realtime/common/Common/src/constants.rs
@@ -1,4 +1,3 @@
-pub type FieldId = u16;
 pub type GameObjectTemplateId = u16;
 ///
 /// Максимальное количество FieldId в игровом объекте (для каждого типа данных)

--- a/modules/matches/Realtime/common/Common/src/protocol/codec/commands/context.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/codec/commands/context.rs
@@ -4,8 +4,8 @@ use std::io::{Cursor, ErrorKind};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use thiserror::Error;
 
+use crate::commands::field::FieldId;
 use crate::commands::CommandTypeId;
-use crate::constants::FieldId;
 use crate::protocol::codec::channel::ChannelType;
 use crate::protocol::codec::commands::header::CommandHeader;
 use crate::protocol::codec::variable_int::{VariableIntReader, VariableIntWriter};
@@ -269,8 +269,8 @@ impl From<&CreatorSource> for u8 {
 pub mod tests {
 	use std::io::Cursor;
 
+	use crate::commands::field::FieldId;
 	use crate::commands::CommandTypeId;
-	use crate::constants::FieldId;
 	use crate::protocol::codec::channel::ChannelType;
 	use crate::protocol::codec::commands::context::CommandContext;
 	use crate::protocol::frame::applications::ChannelGroup;

--- a/modules/matches/Realtime/common/Common/src/protocol/codec/commands/encoder.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/codec/commands/encoder.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
+use crate::commands::field::FieldId;
 use crate::commands::CommandTypeId;
-use crate::constants::FieldId;
 use crate::protocol::codec::channel::ChannelType;
 use crate::protocol::codec::commands::context::CommandContext;
 use crate::protocol::frame::applications::{BothDirectionCommand, ChannelGroup, CommandWithChannel};

--- a/modules/matches/Realtime/server/src/debug/dump/convert.rs
+++ b/modules/matches/Realtime/server/src/debug/dump/convert.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cheetah_matches_realtime_common::constants::FieldId;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::room::owner::GameObjectOwner;
 
 use crate::debug::proto::admin;

--- a/modules/matches/Realtime/server/src/debug/tracer/filter.rs
+++ b/modules/matches/Realtime/server/src/debug/tracer/filter.rs
@@ -1,5 +1,6 @@
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::FieldType;
-use cheetah_matches_realtime_common::constants::{FieldId, GameObjectTemplateId};
+use cheetah_matches_realtime_common::constants::GameObjectTemplateId;
 use cheetah_matches_realtime_common::room::object::GameObjectId;
 use cheetah_matches_realtime_common::room::owner::GameObjectOwner;
 use cheetah_matches_realtime_common::room::RoomMemberId;
@@ -119,9 +120,10 @@ impl Rule {
 #[cfg(test)]
 mod tests {
 	use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+	use cheetah_matches_realtime_common::commands::field::FieldId;
 	use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 	use cheetah_matches_realtime_common::commands::types::event::EventCommand;
-	use cheetah_matches_realtime_common::constants::{FieldId, GameObjectTemplateId};
+	use cheetah_matches_realtime_common::constants::GameObjectTemplateId;
 	use cheetah_matches_realtime_common::room::object::GameObjectId;
 	use cheetah_matches_realtime_common::room::owner::GameObjectOwner;
 	use cheetah_matches_realtime_common::room::RoomMemberId;

--- a/modules/matches/Realtime/server/src/grpc/from.rs
+++ b/modules/matches/Realtime/server/src/grpc/from.rs
@@ -3,8 +3,8 @@ use cheetah_matches_realtime_common::{commands::FieldValue, room::access::Access
 use crate::debug::proto::shared::{field_value::Variant as VariantDebug, FieldValue as GRPCFieldValueDebug};
 use crate::grpc::proto::internal;
 use crate::grpc::proto::shared::{self, field_value::Variant, FieldValue as GRPCFieldValue};
-use crate::room::object::Field;
 use crate::room::template::config;
+use cheetah_matches_realtime_common::commands::field::Field;
 
 impl From<internal::RoomTemplate> for config::RoomTemplate {
 	fn from(source: internal::RoomTemplate) -> config::RoomTemplate {

--- a/modules/matches/Realtime/server/src/room/action.rs
+++ b/modules/matches/Realtime/server/src/room/action.rs
@@ -1,10 +1,11 @@
+use cheetah_matches_realtime_common::commands::field::Field;
 use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 use cheetah_matches_realtime_common::room::object::GameObjectId;
 use cheetah_matches_realtime_common::room::owner::GameObjectOwner;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::room::command::ServerCommandError;
-use crate::room::object::{Field, GameObject, S2CCommandWithFieldInfo};
+use crate::room::object::{GameObject, S2CCommandWithFieldInfo};
 use crate::room::template::config::Permission;
 use crate::room::Room;
 

--- a/modules/matches/Realtime/server/src/room/command/compare_and_set.rs
+++ b/modules/matches/Realtime/server/src/room/command/compare_and_set.rs
@@ -1,17 +1,17 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use cheetah_matches_realtime_common::commands::field::{Field, FieldId};
 use cheetah_matches_realtime_common::commands::{
 	s2c::S2CCommand,
 	types::{long::CompareAndSetLongCommand, structure::CompareAndSetStructureCommand},
 };
 use cheetah_matches_realtime_common::commands::{FieldType, FieldValue};
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::room::object::GameObjectId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::room::command::{ServerCommandError, ServerCommandExecutor};
-use crate::room::object::{Field, GameObject, S2CCommandWithFieldInfo};
+use crate::room::object::{GameObject, S2CCommandWithFieldInfo};
 use crate::room::template::config::Permission;
 use crate::room::Room;
 
@@ -145,22 +145,22 @@ fn reset_value(object: &mut GameObject, field_id: FieldId, value: &FieldValue) -
 
 #[cfg(test)]
 mod tests {
+	use cheetah_matches_realtime_common::commands::field::FieldId;
 	use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 	use cheetah_matches_realtime_common::commands::types::long::CompareAndSetLongCommand;
 	use cheetah_matches_realtime_common::commands::types::structure::CompareAndSetStructureCommand;
 	use cheetah_matches_realtime_common::commands::FieldType;
-	use cheetah_matches_realtime_common::constants::FieldId;
 	use cheetah_matches_realtime_common::room::access::AccessGroups;
 	use cheetah_matches_realtime_common::room::object::GameObjectId;
 	use cheetah_matches_realtime_common::room::owner::GameObjectOwner;
 	use cheetah_matches_realtime_common::room::RoomMemberId;
 
 	use crate::room::command::ServerCommandExecutor;
-	use crate::room::object::Field;
 	use crate::room::template::config::{
 		GameObjectTemplatePermission, GroupsPermissionRule, MemberTemplate, Permission, PermissionField, RoomTemplate,
 	};
 	use crate::room::Room;
+	use cheetah_matches_realtime_common::commands::field::Field;
 
 	///
 	/// Проверяем что при выполнении нескольких команд соблюдаются гарантии CompareAndSet

--- a/modules/matches/Realtime/server/src/room/command/double.rs
+++ b/modules/matches/Realtime/server/src/room/command/double.rs
@@ -1,3 +1,4 @@
+use cheetah_matches_realtime_common::commands::field::Field;
 use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 use cheetah_matches_realtime_common::commands::types::field::SetFieldCommand;
 use cheetah_matches_realtime_common::commands::types::float::IncrementDoubleC2SCommand;
@@ -5,7 +6,7 @@ use cheetah_matches_realtime_common::commands::FieldType;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::room::command::{ServerCommandError, ServerCommandExecutor};
-use crate::room::object::{Field, GameObject};
+use crate::room::object::GameObject;
 use crate::room::template::config::Permission;
 use crate::room::Room;
 

--- a/modules/matches/Realtime/server/src/room/command/event.rs
+++ b/modules/matches/Realtime/server/src/room/command/event.rs
@@ -1,10 +1,11 @@
+use cheetah_matches_realtime_common::commands::field::Field;
 use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 use cheetah_matches_realtime_common::commands::types::event::{EventCommand, TargetEventCommand};
 use cheetah_matches_realtime_common::commands::FieldType;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::room::command::{ServerCommandError, ServerCommandExecutor};
-use crate::room::object::{Field, GameObject};
+use crate::room::object::GameObject;
 use crate::room::template::config::Permission;
 use crate::room::Room;
 

--- a/modules/matches/Realtime/server/src/room/command/field.rs
+++ b/modules/matches/Realtime/server/src/room/command/field.rs
@@ -1,9 +1,10 @@
+use cheetah_matches_realtime_common::commands::field::Field;
 use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 use cheetah_matches_realtime_common::commands::types::field::DeleteFieldCommand;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::room::command::{ServerCommandError, ServerCommandExecutor};
-use crate::room::object::{Field, GameObject};
+use crate::room::object::GameObject;
 use crate::room::template::config::Permission;
 use crate::room::Room;
 

--- a/modules/matches/Realtime/server/src/room/command/long.rs
+++ b/modules/matches/Realtime/server/src/room/command/long.rs
@@ -1,3 +1,4 @@
+use cheetah_matches_realtime_common::commands::field::Field;
 use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 use cheetah_matches_realtime_common::commands::types::field::SetFieldCommand;
 use cheetah_matches_realtime_common::commands::types::long::IncrementLongC2SCommand;
@@ -5,7 +6,7 @@ use cheetah_matches_realtime_common::commands::FieldType;
 use cheetah_matches_realtime_common::room::RoomMemberId;
 
 use crate::room::command::{ServerCommandError, ServerCommandExecutor};
-use crate::room::object::{Field, GameObject};
+use crate::room::object::GameObject;
 use crate::room::template::config::Permission;
 use crate::room::Room;
 

--- a/modules/matches/Realtime/server/src/room/command/mod.rs
+++ b/modules/matches/Realtime/server/src/room/command/mod.rs
@@ -1,12 +1,13 @@
 use thiserror::Error;
 
 use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+use cheetah_matches_realtime_common::commands::field::Field;
 use cheetah_matches_realtime_common::constants::GameObjectTemplateId;
 use cheetah_matches_realtime_common::room::access::AccessGroups;
 use cheetah_matches_realtime_common::room::object::GameObjectId;
 use cheetah_matches_realtime_common::room::{RoomId, RoomMemberId};
 
-use crate::room::object::{Field, GameObjectError};
+use crate::room::object::GameObjectError;
 use crate::room::Room;
 
 pub mod compare_and_set;

--- a/modules/matches/Realtime/server/src/room/command/structure.rs
+++ b/modules/matches/Realtime/server/src/room/command/structure.rs
@@ -11,11 +11,11 @@ mod tests {
 	use cheetah_matches_realtime_common::room::RoomMemberId;
 
 	use crate::room::command::ServerCommandExecutor;
-	use crate::room::object::Field;
 	use crate::room::template::config::{
 		GameObjectTemplatePermission, GroupsPermissionRule, MemberTemplate, Permission, PermissionField, RoomTemplate,
 	};
 	use crate::room::Room;
+	use cheetah_matches_realtime_common::commands::field::Field;
 
 	const FIELD_ID: u16 = 100;
 

--- a/modules/matches/Realtime/server/src/room/object.rs
+++ b/modules/matches/Realtime/server/src/room/object.rs
@@ -1,9 +1,10 @@
 use thiserror::Error;
 
+use cheetah_matches_realtime_common::commands::field::{Field, FieldId};
 use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 use cheetah_matches_realtime_common::commands::types::create::{CreateGameObjectCommand, GameObjectCreatedS2CCommand};
-use cheetah_matches_realtime_common::commands::{field_type::ToFieldType, FieldType, FieldValue};
-use cheetah_matches_realtime_common::constants::{FieldId, GameObjectTemplateId};
+use cheetah_matches_realtime_common::commands::{field::ToFieldType, FieldType, FieldValue};
+use cheetah_matches_realtime_common::constants::GameObjectTemplateId;
 use cheetah_matches_realtime_common::room::access::AccessGroups;
 use cheetah_matches_realtime_common::room::object::GameObjectId;
 use cheetah_matches_realtime_common::room::RoomMemberId;
@@ -145,21 +146,16 @@ pub struct S2CCommandWithFieldInfo {
 	pub command: S2CCommand,
 }
 
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
-pub struct Field {
-	pub id: FieldId,
-	pub field_type: FieldType,
-}
-
 #[cfg(test)]
 mod tests {
+	use cheetah_matches_realtime_common::commands::field::Field;
 	use cheetah_matches_realtime_common::commands::s2c::S2CCommand;
 	use cheetah_matches_realtime_common::commands::FieldType;
 	use cheetah_matches_realtime_common::room::access::AccessGroups;
 	use cheetah_matches_realtime_common::room::object::GameObjectId;
 	use cheetah_matches_realtime_common::room::owner::GameObjectOwner;
 
-	use crate::room::object::{CreateCommandsCollector, Field, FieldValue, GameObject, S2CCommandWithFieldInfo};
+	use crate::room::object::{CreateCommandsCollector, FieldValue, GameObject, S2CCommandWithFieldInfo};
 
 	///
 	/// Проверяем что все типы данных преобразованы в команды

--- a/modules/matches/Realtime/server/src/room/sender.rs
+++ b/modules/matches/Realtime/server/src/room/sender.rs
@@ -121,12 +121,13 @@ impl Room {
 
 #[cfg(test)]
 mod tests {
+	use cheetah_matches_realtime_common::commands::field::Field;
 	use cheetah_matches_realtime_common::commands::s2c::{S2CCommand, S2CCommandWithCreator};
 	use cheetah_matches_realtime_common::commands::{types::field::SetFieldCommand, FieldType};
 	use cheetah_matches_realtime_common::room::access::AccessGroups;
 	use cheetah_matches_realtime_common::room::owner::GameObjectOwner;
 
-	use crate::room::object::{Field, S2CCommandWithFieldInfo};
+	use crate::room::object::S2CCommandWithFieldInfo;
 	use crate::room::template::config::{MemberTemplate, Permission, RoomTemplate};
 	use crate::room::Room;
 

--- a/modules/matches/Realtime/server/src/room/template/config.rs
+++ b/modules/matches/Realtime/server/src/room/template/config.rs
@@ -1,15 +1,16 @@
 use std::collections::HashMap;
 
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use fnv::FnvBuildHasher;
 
 use cheetah_matches_realtime_common::commands::FieldType;
 use cheetah_matches_realtime_common::commands::FieldValue;
-use cheetah_matches_realtime_common::constants::{FieldId, GameObjectTemplateId};
+use cheetah_matches_realtime_common::constants::GameObjectTemplateId;
 use cheetah_matches_realtime_common::room::access::AccessGroups;
 use cheetah_matches_realtime_common::room::object::GameObjectId;
 use cheetah_matches_realtime_common::room::MemberPrivateKey;
 
-use crate::room::object::Field;
+use cheetah_matches_realtime_common::commands::field::Field;
 
 ///
 /// Шаблон для создания комнаты
@@ -113,16 +114,17 @@ impl MemberTemplate {
 
 #[cfg(test)]
 mod tests {
+	use cheetah_matches_realtime_common::commands::field::FieldId;
 	use cheetah_matches_realtime_common::commands::FieldType;
-	use cheetah_matches_realtime_common::constants::{FieldId, GameObjectTemplateId};
+	use cheetah_matches_realtime_common::constants::GameObjectTemplateId;
 	use cheetah_matches_realtime_common::room::access::AccessGroups;
 	use cheetah_matches_realtime_common::room::object::GameObjectId;
 
-	use crate::room::object::Field;
 	use crate::room::template::config::{
 		GameObjectTemplate, GameObjectTemplatePermission, GroupsPermissionRule, MemberTemplate, Permission, PermissionField, Permissions,
 		UserTemplateError,
 	};
+	use cheetah_matches_realtime_common::commands::field::Field;
 
 	impl MemberTemplate {
 		pub fn stub(access_group: AccessGroups) -> Self {

--- a/modules/matches/Realtime/server/src/room/template/permission.rs
+++ b/modules/matches/Realtime/server/src/room/template/permission.rs
@@ -5,8 +5,8 @@ use fnv::FnvBuildHasher;
 use cheetah_matches_realtime_common::constants::GameObjectTemplateId;
 use cheetah_matches_realtime_common::room::access::AccessGroups;
 
-use crate::room::object::Field;
 use crate::room::template::config::{GroupsPermissionRule, Permission, Permissions};
+use cheetah_matches_realtime_common::commands::field::Field;
 
 #[derive(Debug)]
 pub struct PermissionManager {
@@ -106,9 +106,9 @@ mod tests {
 	use cheetah_matches_realtime_common::commands::FieldType;
 	use cheetah_matches_realtime_common::room::access::AccessGroups;
 
-	use crate::room::object::Field;
 	use crate::room::template::config::{GameObjectTemplatePermission, GroupsPermissionRule, Permission, PermissionField, Permissions};
 	use crate::room::template::permission::PermissionManager;
+	use cheetah_matches_realtime_common::commands::field::Field;
 
 	#[test]
 	fn should_default_permission() {

--- a/modules/matches/Realtime/server/src/server/measurers.rs
+++ b/modules/matches/Realtime/server/src/server/measurers.rs
@@ -7,8 +7,8 @@ use prometheus_measures_exporter::measurers_by_label::{
 };
 
 use cheetah_matches_realtime_common::commands::c2s::C2SCommand;
+use cheetah_matches_realtime_common::commands::field::FieldId;
 use cheetah_matches_realtime_common::commands::FieldType;
-use cheetah_matches_realtime_common::constants::FieldId;
 use cheetah_matches_realtime_common::protocol::commands::output::CommandWithChannelType;
 use cheetah_matches_realtime_common::protocol::frame::applications::{BothDirectionCommand, CommandWithChannel};
 


### PR DESCRIPTION
сделал этот коммит для #120, но уже не актуален после последнего обсуждения. 
Все равно выглядит, как минорное улучшение чтобы FieldId, FieldType и Field были в одном файле в одном пакете. 

Основные изменения в modules/matches/Realtime/common/Common/src/commands/field.rs, остальное - импорты