### PR TITLE
feat(#230 server/Realtime) grpc MarkRoomAsReady and GetRoomInfo

### DIFF
--- a/modules/matches/Realtime/client/rust/Realtime/tests/helpers/server.rs
+++ b/modules/matches/Realtime/client/rust/Realtime/tests/helpers/server.rs
@@ -1,3 +1,4 @@
+use fnv::FnvHashSet;
 use std::net::SocketAddr;
 
 use cheetah_matches_realtime::room::template::config::{
@@ -52,7 +53,7 @@ impl IntegrationTestServerBuilder {
 	pub fn build(self) -> (SocketAddr, RoomsServerManager, RoomId) {
 		let socket = bind_to_free_socket().unwrap();
 		let addr = socket.local_addr().unwrap();
-		let mut server = RoomsServerManager::new(socket).unwrap();
+		let mut server = RoomsServerManager::new(socket, FnvHashSet::default()).unwrap();
 		let room_id = server.create_room(self.template).ok().unwrap();
 		(addr, server, room_id)
 	}

--- a/modules/matches/Realtime/proto/matches.realtime.internal.proto
+++ b/modules/matches/Realtime/proto/matches.realtime.internal.proto
@@ -39,7 +39,21 @@ service Realtime {
    */
   rpc DeleteRoom(DeleteRoomRequest) returns (DeleteRoomResponse);
 
+  /**
+  Настроить форвардинг команд суперпользователям совпадающих с фильтром вместо execute для комнаты
+   */
   rpc PutForwardedCommandConfig(PutForwardedCommandConfigRequest) returns (PutForwardedCommandConfigResponse);
+
+  /**
+  Метод вызывается плагином, когда он закончил настройку новой комнаты и разрешает выполнять команды от пользователей.
+  Чтобы статус комнаты переключился в ready, все плагины переданные в env PLUGIN_NAMES должны вызвать этот метод.
+   */
+  rpc MarkRoomAsReady(MarkRoomAsReadyRequest) returns(MarkRoomAsReadyResponse);
+
+  /**
+  Получить информацию о комнате
+   */
+  rpc GetRoomInfo(GetRoomInfoRequest) returns(GetRoomInfoResponse);
 }
 
 
@@ -190,4 +204,25 @@ message PutForwardedCommandConfigRequest {
 
 message PutForwardedCommandConfigResponse {
 
+}
+
+message MarkRoomAsReadyRequest {
+  uint64 room_id = 1;
+  // имя плагина должно совпадать с одним из переменной окружения PLUGIN_NAMES
+  string plugin_name = 2;
+}
+
+message MarkRoomAsReadyResponse {
+
+}
+
+message GetRoomInfoRequest {
+  uint64 room_id = 1;
+}
+
+message GetRoomInfoResponse {
+  uint64 room_id = 1;
+  // если комната ready, не-суперпользователи могут подключиться к комнате и их команды будут выполняться.
+  // пока комната не-ready, только суперпользователи могут подключиться и выполнять команды в комнате.
+  bool ready = 2;
 }

--- a/modules/matches/Realtime/server/src/bin/service.rs
+++ b/modules/matches/Realtime/server/src/bin/service.rs
@@ -1,4 +1,5 @@
 use cheetah_matches_realtime::builder::ServerBuilder;
+use fnv::FnvHashSet;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -7,7 +8,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let mut builder = ServerBuilder::default()
 		.set_admin_grpc_address(cheetah_libraries_microservice::get_admin_service_binding_addr())
 		.set_internal_grpc_address(cheetah_libraries_microservice::get_internal_service_binding_addr())
-		.set_game_address("0.0.0.0:5555".parse().unwrap());
+		.set_game_address("0.0.0.0:5555".parse().unwrap())
+		.set_plugin_names(get_plugin_names("PLUGIN_NAMES"));
 
 	if std::env::var("ENABLE_AGONES").is_ok() {
 		builder = builder.enable_agones();
@@ -17,4 +19,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	server.run().await;
 
 	Ok(())
+}
+
+fn get_plugin_names(env_var: &str) -> FnvHashSet<String> {
+	// плагины должны быть в формате PLUGIN_NAMES=plugin_1;plugin_2
+	cheetah_libraries_microservice::get_env_or_default(env_var, "")
+		.split_terminator(';')
+		.map(ToString::to_string)
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::get_plugin_names;
+	use fnv::FnvHashSet;
+	use rand::distributions::{Alphanumeric, DistString};
+	use std::env;
+
+	#[test]
+	fn test_get_plugin_names() {
+		let env_var = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+		env::set_var(&env_var, "plugin_1;plugin_2");
+		assert_eq!(
+			FnvHashSet::<String>::from_iter(["plugin_1".to_string(), "plugin_2".to_string()]),
+			get_plugin_names(&env_var)
+		);
+		env::remove_var(&env_var);
+	}
+
+	#[test]
+	fn test_get_plugin_names_empty() {
+		let env_var = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+		let plugin_names = get_plugin_names(&env_var);
+		assert!(plugin_names.is_empty(), "plugin_names are not empty: {:?}", plugin_names);
+	}
 }

--- a/modules/matches/Realtime/server/src/server/measurers.rs
+++ b/modules/matches/Realtime/server/src/server/measurers.rs
@@ -56,6 +56,12 @@ pub struct Measurers {
 	server_cycle_execution_time: Histogram,
 }
 
+impl Default for Measurers {
+	fn default() -> Self {
+		Measurers::new(prometheus::default_registry())
+	}
+}
+
 impl Measurers {
 	#[must_use]
 	pub fn new(registry: &Registry) -> Self {

--- a/modules/matches/Realtime/server/src/server/network.rs
+++ b/modules/matches/Realtime/server/src/server/network.rs
@@ -221,7 +221,7 @@ mod tests {
 	#[test]
 	fn should_not_panic_when_wrong_in_data() {
 		let mut udp_server = create_network_layer();
-		let mut rooms = Rooms::new(Rc::new(RefCell::new(Measurers::new(prometheus::default_registry()))));
+		let mut rooms = Rooms::default();
 		let buffer = [0; MAX_FRAME_SIZE];
 		let usize = 100_usize;
 		udp_server.process_in_frame(
@@ -236,7 +236,7 @@ mod tests {
 	#[test]
 	fn should_not_panic_when_wrong_user() {
 		let mut udp_server = create_network_layer();
-		let mut rooms = Rooms::new(Rc::new(RefCell::new(Measurers::new(prometheus::default_registry()))));
+		let mut rooms = Rooms::default();
 		let mut buffer = [0; MAX_FRAME_SIZE];
 		let mut frame = OutFrame::new(0);
 		frame.headers.add(Header::MemberAndRoomId(MemberAndRoomId { member_id: 0, room_id: 0 }));
@@ -247,7 +247,7 @@ mod tests {
 	#[test]
 	fn should_not_panic_when_missing_user_header() {
 		let mut udp_server = create_network_layer();
-		let mut rooms = Rooms::new(Rc::new(RefCell::new(Measurers::new(prometheus::default_registry()))));
+		let mut rooms = Rooms::default();
 		let mut buffer = [0; MAX_FRAME_SIZE];
 		let frame = OutFrame::new(0);
 		let size = frame.encode(&mut Cipher::new(&[0; 32].as_slice().into()), &mut buffer).unwrap();
@@ -260,7 +260,7 @@ mod tests {
 	#[test]
 	fn should_keep_address_from_last_frame() {
 		let mut udp_server = create_network_layer();
-		let mut rooms = Rooms::new(Rc::new(RefCell::new(Measurers::new(prometheus::default_registry()))));
+		let mut rooms = Rooms::default();
 		let mut buffer = [0; MAX_FRAME_SIZE];
 
 		let user_template = MemberTemplate::new_member(Default::default(), Default::default());


### PR DESCRIPTION
Добавил 2 новых метода в internal grpc для конфигурирования комнаты.

- Сервер запускается с переменной окружения, в которой указаны имена плагинов.
- Каждый плагин после настройки новой комнаты вызывает MarkRoomAsReady со своим именем.
- Когда все плагины из переменной окружения вызвали MarkRoomAsReady для комнаты, её статус меняется на ready в ответе GetRoomInfo.
- Пока комната не ready, статус соединения не-суперпользователей остается connected=false

- [x] тесты 

Closes #230 