### PR TITLE
enable more clippy and rustc linters

### DIFF
--- a/.github/workflows/templates.build-on-linux.yml
+++ b/.github/workflows/templates.build-on-linux.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-gnu-old-glib:0.0.5
+      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-gnu-old-glib:0.0.6
     steps:
       - uses: actions/checkout@v3
       - name: Build Client

--- a/.github/workflows/templates.build.docker-images.yml
+++ b/.github/workflows/templates.build.docker-images.yml
@@ -9,7 +9,7 @@ jobs:
   build-docker-images:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-musl:0.0.4
+      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-musl:0.0.5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3

--- a/.github/workflows/test.cargo-clippy.yml
+++ b/.github/workflows/test.cargo-clippy.yml
@@ -8,7 +8,7 @@ jobs:
   test-cargo-clippy:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-musl:0.0.4
+      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-musl:0.0.5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
@@ -21,7 +21,6 @@ jobs:
           key: rust-clippy-v1-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             rust-clippy-v1-
-      - run: cargo install cargo-cranky
       - name: Lint cargo clippy
         run: cd modules/ && cargo cranky --workspace --all-targets --all-features -- -D warnings
 

--- a/.github/workflows/test.cargo-fmt.yml
+++ b/.github/workflows/test.cargo-fmt.yml
@@ -8,7 +8,7 @@ jobs:
   test-cargo-fmt:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-musl:0.0.4
+      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-musl:0.0.5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3

--- a/.github/workflows/test.cargo-udeps.yml
+++ b/.github/workflows/test.cargo-udeps.yml
@@ -8,7 +8,7 @@ jobs:
   test-cargo-udeps:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-musl:0.0.4
+      image: ghcr.io/cheetah-game-platform/rust-builder-x86_64-unknown-linux-musl:0.0.5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3

--- a/modules/Cranky.toml
+++ b/modules/Cranky.toml
@@ -7,26 +7,78 @@ deny = [
 warn = [
     "clippy::all",
     "clippy::pedantic",
-    #    "clippy::restriction",
+    "clippy::restriction",
 
+    # https://doc.rust-lang.org/rustc/lints/groups.html
+    # rustc -W help
     "warnings",
-    #    "future-incompatible",
-    #    "nonstandard-style",
+    "future-incompatible",
+    "nonstandard-style",
     "rust-2018-compatibility",
     "rust-2018-idioms",
     "rust-2021-compatibility",
     "unused",
+    # https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    "macro_use_extern_crate",
+    "meta_variable_misuse",
+    "missing_abi",
+    "non_ascii_idents",
+    "noop_method_call",
+    "single_use_lifetimes",
+    "trivial_casts",
+    "trivial_numeric_casts",
+    "unsafe_op_in_unsafe_fn",
+    "unstable_features",
+    "unused_import_braces",
+    "unused_lifetimes",
+    "unused_tuple_struct_fields",
 ]
 
 allow = [
-    "clippy::missing_errors_doc",
-    "clippy::return_self_not_must_use", # tonic
-    "clippy::match_same_arms",
-    "clippy::too_many_lines",
-    "clippy::module_name_repetitions",
-    "clippy::wildcard_imports", # tonic::codegen::*
-    "clippy::default_trait_access", # todo many no auto fix
-    "clippy::missing_panics_doc", # todo check where unwrap can be changed to result
-    "clippy::similar_names", # tonic
+    # clippy::style exceptions
+    "clippy::missing_safety_doc",
+    # clippy::pedantic exceptions
+    "clippy::default_trait_access", # todo
     "clippy::implicit_hasher", # todo
+    "clippy::match_same_arms",
+    "clippy::missing_errors_doc",
+    "clippy::missing_panics_doc",
+    "clippy::module_name_repetitions",
+    "clippy::similar_names",
+    "clippy::too_many_lines",
+    # clippy::restriction exceptions
+    "clippy::arithmetic_side_effects",
+    "clippy::as_conversions",
+    "clippy::decimal_literal_representation",
+    "clippy::default_numeric_fallback",
+    "clippy::exhaustive_enums",
+    "clippy::exhaustive_structs",
+    "clippy::expect_used", # todo
+    "clippy::float_arithmetic",
+    "clippy::implicit_return",
+    "clippy::indexing_slicing", # todo
+    "clippy::integer_arithmetic",
+    "clippy::integer_division",
+    "clippy::let_underscore_must_use",
+    "clippy::missing_docs_in_private_items",
+    "clippy::missing_inline_in_public_items",
+    "clippy::mod_module_files",
+    "clippy::modulo_arithmetic",
+    "clippy::multiple_inherent_impl", # todo
+    "clippy::non_ascii_literal",
+    "clippy::panic", # todo
+    "clippy::panic_in_result_fn",
+    "clippy::pattern_type_mismatch",
+    "clippy::pub_use",
+    "clippy::self_named_module_files",
+    "clippy::separated_literal_suffix", # we use clippy::unseparated_literal_suffix instead
+    "clippy::shadow_reuse",
+    "clippy::shadow_unrelated", # todo
+    "clippy::single_char_lifetime_names",
+    "clippy::std_instead_of_alloc",
+    "clippy::std_instead_of_core",
+    "clippy::string_slice", # todo
+    "clippy::undocumented_unsafe_blocks",
+    "clippy::unwrap_used", # todo
+    "clippy::wildcard_enum_match_arm", # todo
 ]

--- a/modules/clippy.toml
+++ b/modules/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/modules/libraries/rust/Microservice/src/lib.rs
+++ b/modules/libraries/rust/Microservice/src/lib.rs
@@ -61,6 +61,8 @@ fn setup_tracer(name: &str, trace_level: tracing::Level) {
 	}
 }
 
+#[allow(clippy::print_stdout)]
+#[allow(clippy::exit)]
 fn setup_panic_hook() {
 	panic::set_hook(Box::new(move |panic_info| {
 		// ставим задачу на выход

--- a/modules/matches/Realtime/client/Rust/Embedded/src/ffi/logs.rs
+++ b/modules/matches/Realtime/client/Rust/Embedded/src/ffi/logs.rs
@@ -4,19 +4,19 @@ use cheetah_matches_realtime_common::trace_collector::TRACER_COLLECTOR;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum LogLevel {
+pub(crate) enum LogLevel {
 	Info,
 	Warn,
 	Error,
 }
 
 #[no_mangle]
-pub extern "C" fn init_logger() {
+pub(crate) extern "C" fn init_logger() {
 	set_max_log_level(LogLevel::Error);
 }
 
 #[no_mangle]
-pub extern "C" fn set_max_log_level(log_level: LogLevel) {
+pub(crate) extern "C" fn set_max_log_level(log_level: LogLevel) {
 	let collector = &mut TRACER_COLLECTOR.lock().unwrap();
 	collector.set_log_level(match log_level {
 		LogLevel::Info => tracing_core::Level::INFO,
@@ -26,7 +26,7 @@ pub extern "C" fn set_max_log_level(log_level: LogLevel) {
 }
 
 #[no_mangle]
-pub extern "C" fn collect_logs(on_log_message: extern "C" fn(LogLevel, *const u16)) {
+pub(crate) extern "C" fn collect_logs(on_log_message: extern "C" fn(LogLevel, *const u16)) {
 	let collector = &mut TRACER_COLLECTOR.lock().unwrap();
 	loop {
 		match collector.items.pop_front() {

--- a/modules/matches/Realtime/client/Rust/Embedded/src/ffi/mod.rs
+++ b/modules/matches/Realtime/client/Rust/Embedded/src/ffi/mod.rs
@@ -4,19 +4,19 @@ use lazy_static::lazy_static;
 
 use crate::EmbeddedServerWrapper;
 
-pub mod logs;
-pub mod member;
-pub mod room;
-pub mod server;
+pub(crate) mod logs;
+pub(crate) mod member;
+pub(crate) mod room;
+pub(crate) mod server;
 
 lazy_static! {
 	static ref REGISTRY: std::sync::Mutex<Registry> = std::sync::Mutex::new(Default::default());
 }
 
-pub type ServerId = u64;
+pub(crate) type ServerId = u64;
 
 #[derive(Default)]
 struct Registry {
-	pub next_server_id: ServerId,
-	pub servers: HashMap<u64, EmbeddedServerWrapper>,
+	pub(crate) next_server_id: ServerId,
+	pub(crate) servers: HashMap<u64, EmbeddedServerWrapper>,
 }

--- a/modules/matches/Realtime/client/Rust/Embedded/src/lib.rs
+++ b/modules/matches/Realtime/client/Rust/Embedded/src/lib.rs
@@ -42,7 +42,7 @@ impl EmbeddedServerWrapper {
 				.build()
 				.await
 		})?;
-		let manager = server.manager.clone();
+		let manager = Arc::clone(&server.manager);
 		let game_socket_addr = server.game_socket_addr;
 		let internal_grpc_socket_addr = server.internal_grpc_tcp_listener.local_addr()?;
 		let admin_grpc_socket_addr = server.admin_grpc_tcp_listener.local_addr()?;
@@ -74,7 +74,7 @@ impl EmbeddedServerWrapper {
 	}
 
 	pub fn shutdown(self) {
-		let manager = self.manager.clone();
+		let manager = Arc::clone(&self.manager);
 		self.runtime.block_on(async move { manager.lock().await.shutdown() });
 		self.runtime.shutdown_background();
 	}

--- a/modules/matches/Realtime/client/Rust/Realtime/src/clients/application_thread.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/src/clients/application_thread.rs
@@ -103,6 +103,7 @@ impl ApplicationThreadClient {
 		Ok(self.state.lock()?.clone())
 	}
 
+	#[allow(clippy::unwrap_in_result)]
 	pub fn get_server_time(&self) -> Option<u64> {
 		*self.server_time.lock().unwrap()
 	}

--- a/modules/matches/Realtime/client/Rust/Realtime/src/clients/registry.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/src/clients/registry.rs
@@ -31,6 +31,7 @@ pub struct Registry {
 }
 
 impl Registry {
+	#[allow(clippy::unwrap_in_result)]
 	pub fn create_client(
 		&mut self,
 		server_address: &str,
@@ -43,7 +44,7 @@ impl Registry {
 
 		let server_time = Arc::new(Mutex::new(None));
 		let state = Arc::new(Mutex::new(ConnectionStatus::Connecting));
-		let state_cloned = state.clone();
+		let state_cloned = Arc::clone(&state);
 		let shared_statistics = SharedClientStatistics::default();
 
 		let (sender, receiver) = std::sync::mpsc::channel();
@@ -58,7 +59,7 @@ impl Registry {
 			receiver,
 			start_frame_id,
 			shared_statistics.clone(),
-			server_time.clone(),
+			Arc::clone(&server_time),
 		)?;
 
 		let handler = thread::Builder::new()

--- a/modules/matches/Realtime/client/Rust/Realtime/src/ffi/client.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/src/ffi/client.rs
@@ -72,7 +72,7 @@ pub extern "C" fn receive(client_id: ClientId) -> u8 {
 #[no_mangle]
 pub extern "C" fn get_server_time(client_id: ClientId, server_out_time: &mut u64) -> u8 {
 	execute_with_client(client_id, |client| {
-		*server_out_time = client.get_server_time().unwrap_or(0_u64);
+		*server_out_time = client.get_server_time().unwrap_or_default();
 		Ok(())
 	})
 }
@@ -135,6 +135,7 @@ pub struct Statistics {
 
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
+#[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe extern "C" fn create_client(
 	addr: *const c_char,
 	member_id: RoomMemberId,

--- a/modules/matches/Realtime/client/Rust/Realtime/src/ffi/command/long_value.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/src/ffi/command/long_value.rs
@@ -57,7 +57,7 @@ pub extern "C" fn compare_and_set_long_value(
 			field_id,
 			current,
 			new,
-			reset: if has_reset { Some(reset) } else { None },
+			reset: has_reset.then_some(reset),
 		}),
 	)
 }

--- a/modules/matches/Realtime/client/Rust/Realtime/src/ffi/command/object.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/src/ffi/command/object.rs
@@ -34,11 +34,7 @@ pub extern "C" fn create_object(client_id: ClientId, template: u16, access_group
 
 #[no_mangle]
 pub extern "C" fn created_object(client_id: ClientId, object_id: &GameObjectIdFFI, room_owner: bool, singleton_key: &BufferFFI) -> u8 {
-	let singleton_key = if singleton_key.len > 0 {
-		Some(BinaryValue::from(singleton_key))
-	} else {
-		None
-	};
+	let singleton_key = (singleton_key.len > 0).then(|| BinaryValue::from(singleton_key));
 	send_command(
 		client_id,
 		C2SCommand::CreatedGameObject(C2SCreatedGameObjectCommand {

--- a/modules/matches/Realtime/client/Rust/Realtime/src/ffi/command/structure.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/src/ffi/command/structure.rs
@@ -47,7 +47,7 @@ pub extern "C" fn compare_and_set_structure(
 			field_id,
 			new: new.into(),
 			object_id: object_id.into(),
-			reset: if has_reset { Some(reset.into()) } else { None },
+			reset: has_reset.then(|| reset.into()),
 		}),
 	)
 }

--- a/modules/matches/Realtime/client/Rust/Realtime/tests/delete_member.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/tests/delete_member.rs
@@ -38,7 +38,6 @@ fn should_disconnect_on_delete_member() {
 
 	execute_with_client(client, |api| {
 		let status = api.get_connection_status().unwrap();
-		println!("{:?}", status);
 		assert!(matches!(status, ConnectionStatus::Disconnected(DisconnectedReason::ByCommand)));
 		Ok(())
 	});

--- a/modules/matches/Realtime/client/Rust/Realtime/tests/delete_room.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/tests/delete_room.rs
@@ -28,7 +28,6 @@ fn should_disconnect_on_delete_room() {
 
 	execute_with_client(client, |api| {
 		let status = api.get_connection_status().unwrap();
-		println!("{:?}", status);
 		assert!(matches!(status, ConnectionStatus::Disconnected(DisconnectedReason::ByCommand)));
 		Ok(())
 	});

--- a/modules/matches/Realtime/client/Rust/Realtime/tests/stress.rs
+++ b/modules/matches/Realtime/client/Rust/Realtime/tests/stress.rs
@@ -45,6 +45,7 @@ extern "C" fn on_object_create(_object_id: &GameObjectIdFFI, _: u16) {
 /// Тестируем работу сервера под большой нагрузкой
 ///
 //#[test]
+#[allow(clippy::print_stderr)]
 pub fn stress_test() {
 	init_logger();
 	let (helper, [client1, client2]) = setup(Default::default());

--- a/modules/matches/Realtime/client/Rust/ServerPlugin/src/ffi/mod.rs
+++ b/modules/matches/Realtime/client/Rust/ServerPlugin/src/ffi/mod.rs
@@ -20,8 +20,9 @@ pub enum ResultCode {
 }
 
 #[no_mangle]
+#[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe extern "C" fn create_plugin(grpc_server_addr: *const c_char, out_plugin_id: &mut ServerPluginId) -> ResultCode {
-	let grpc_server_addr_as_string = CStr::from_ptr(grpc_server_addr).to_str().unwrap().to_string();
+	let grpc_server_addr_as_string = CStr::from_ptr(grpc_server_addr).to_str().unwrap().to_owned();
 	execute(|registry| {
 		let plugin = ServerPlugin::new(grpc_server_addr_as_string);
 		match plugin {

--- a/modules/matches/Realtime/client/Rust/ServerPlugin/src/proto.rs
+++ b/modules/matches/Realtime/client/Rust/ServerPlugin/src/proto.rs
@@ -1,4 +1,13 @@
 pub mod matches {
+	#![allow(
+		clippy::empty_structs_with_brackets,
+		clippy::derive_partial_eq_without_eq,
+		clippy::wildcard_imports,
+		clippy::return_self_not_must_use,
+		clippy::clone_on_ref_ptr,
+		clippy::similar_names
+	)]
+
 	pub mod realtime {
 		pub mod shared {
 			tonic::include_proto!("cheetah.matches.realtime.shared");

--- a/modules/matches/Realtime/client/Rust/ServerPlugin/src/registry/mod.rs
+++ b/modules/matches/Realtime/client/Rust/ServerPlugin/src/registry/mod.rs
@@ -25,7 +25,7 @@ impl Registry {
 	}
 
 	pub fn get_plugin(&mut self, id: ServerPluginId) -> Option<&mut ServerPlugin> {
-		return self.plugins.get_mut(&id);
+		self.plugins.get_mut(&id)
 	}
 }
 

--- a/modules/matches/Realtime/client/Rust/ServerPlugin/src/registry/stubs.rs
+++ b/modules/matches/Realtime/client/Rust/ServerPlugin/src/registry/stubs.rs
@@ -19,18 +19,17 @@ use crate::proto::matches::realtime::internal::{
 
 pub struct RealtimeStub<CreatedEventStubFunc, Fut>
 where
-	CreatedEventStubFunc: Fn(Sender<Result<RoomLifecycleResponse, Status>>) -> Fut,
-	CreatedEventStubFunc: Send + Sync + 'static,
+	CreatedEventStubFunc: Fn(Sender<Result<RoomLifecycleResponse, Status>>) -> Fut + Send + Sync + 'static,
 	Fut: Future<Output = ()> + 'static + Send + Sync,
 {
 	pub created_event_stub_function: CreatedEventStubFunc,
 }
 
 #[tonic::async_trait]
+#[allow(clippy::unreachable)]
 impl<CreatedEventStubFunc, Fut> Realtime for RealtimeStub<CreatedEventStubFunc, Fut>
 where
-	CreatedEventStubFunc: Fn(Sender<Result<RoomLifecycleResponse, Status>>) -> Fut,
-	CreatedEventStubFunc: Send + Sync + 'static,
+	CreatedEventStubFunc: Fn(Sender<Result<RoomLifecycleResponse, Status>>) -> Fut + Send + Sync + 'static,
 	Fut: Future<Output = ()> + 'static + Send + Sync,
 {
 	async fn create_room(&self, _request: Request<RoomTemplate>) -> Result<Response<RoomIdResponse>, Status> {
@@ -66,28 +65,30 @@ where
 
 	async fn put_forwarded_command_config(
 		&self,
-		_: Request<PutForwardedCommandConfigRequest>,
+		_request: Request<PutForwardedCommandConfigRequest>,
 	) -> Result<Response<PutForwardedCommandConfigResponse>, Status> {
 		unreachable!()
 	}
 
-	async fn mark_room_as_ready(&self, _: Request<MarkRoomAsReadyRequest>) -> Result<Response<MarkRoomAsReadyResponse>, Status> {
+	async fn mark_room_as_ready(&self, _request: Request<MarkRoomAsReadyRequest>) -> Result<Response<MarkRoomAsReadyResponse>, Status> {
 		unreachable!()
 	}
 
-	async fn get_room_info(&self, _: Request<GetRoomInfoRequest>) -> Result<Response<GetRoomInfoResponse>, Status> {
+	async fn get_room_info(&self, _request: Request<GetRoomInfoRequest>) -> Result<Response<GetRoomInfoResponse>, Status> {
 		unreachable!()
 	}
 
-	async fn update_room_permissions(&self, _: Request<UpdateRoomPermissionsRequest>) -> Result<Response<UpdateRoomPermissionsResponse>, Status> {
+	async fn update_room_permissions(
+		&self,
+		_request: Request<UpdateRoomPermissionsRequest>,
+	) -> Result<Response<UpdateRoomPermissionsResponse>, Status> {
 		unreachable!()
 	}
 }
 
 pub fn create_stub_server<F, Fut>(f: F) -> (Runtime, JoinHandle<Result<(), Error>>, Channel)
 where
-	F: Fn(Sender<Result<RoomLifecycleResponse, Status>>) -> Fut,
-	F: Send + Sync + 'static,
+	F: Fn(Sender<Result<RoomLifecycleResponse, Status>>) -> Fut + Send + Sync + 'static,
 	Fut: Future<Output = ()> + 'static + Send + Sync,
 {
 	let (client, server) = tokio::io::duplex(1024);

--- a/modules/matches/Realtime/common/Common/src/collections/event_collector_by_time.rs
+++ b/modules/matches/Realtime/common/Common/src/collections/event_collector_by_time.rs
@@ -142,7 +142,7 @@ mod tests {
 	///
 	/// Если не прошло время агрегации - сумма и количество не может быть определено
 	///
-	pub fn should_return_none_if_not_enough_duration() {
+	pub(crate) fn should_return_none_if_not_enough_duration() {
 		let (mut collector, _) = setup();
 		let now = Instant::now();
 		collector.on_event(now);
@@ -153,7 +153,7 @@ mod tests {
 	/// Проверяем агрегирование в рамках одного временного диапазона
 	///
 	#[test]
-	pub fn should_return_sum_and_count_for_one_aggregation() {
+	pub(crate) fn should_return_sum_and_count_for_one_aggregation() {
 		let (mut collector, duration) = setup();
 		let now = Instant::now();
 		collector.on_event(now);
@@ -166,7 +166,7 @@ mod tests {
 	/// Проверяем агрегирование в рамках двух временных диапазонов
 	///
 	#[test]
-	pub fn should_return_sum_and_count_for_two_aggregation() {
+	pub(crate) fn should_return_sum_and_count_for_two_aggregation() {
 		let (mut collector, duration) = setup();
 		let mut now = Instant::now();
 		collector.on_event(now);

--- a/modules/matches/Realtime/common/Common/src/commands/binary_value.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/binary_value.rs
@@ -17,10 +17,7 @@ impl From<&[u8]> for BinaryValue {
 impl BinaryValue {
 	pub(crate) fn decode(input: &mut Cursor<&[u8]>) -> std::io::Result<Self> {
 		let mut result = BinaryValue(Default::default());
-		let size = input
-			.read_variable_u64()?
-			.try_into()
-			.map_err(|_| Error::new(ErrorKind::InvalidData, "could not cast size into usize".to_string()))?;
+		let size = input.read_variable_u64()?.try_into().map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 		if size > result.0.capacity() {
 			return Err(Error::new(ErrorKind::InvalidData, format!("Event buffer size to big {}", size)));
 		}

--- a/modules/matches/Realtime/common/Common/src/commands/c2s.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/c2s.rs
@@ -165,10 +165,10 @@ impl C2SCommand {
 			}
 			C2SCommand::Event(command) => format!("{:?}", command.event.as_slice()),
 			C2SCommand::TargetEvent(command) => format!("target_member = {:?}, value = {:?}", command.target, command.event.event),
-			C2SCommand::Delete(_) => "".to_string(),
+			C2SCommand::Delete(_) => String::new(),
 			C2SCommand::DeleteField(command) => format!("field_type = {:?}", command.field_type),
-			C2SCommand::AttachToRoom => "".to_string(),
-			C2SCommand::DetachFromRoom => "".to_string(),
+			C2SCommand::AttachToRoom => String::new(),
+			C2SCommand::DetachFromRoom => String::new(),
 			C2SCommand::Forwarded(command) => format!("forward: member({:?}) command({:?})", command.creator, command.c2s.get_trace_string()),
 		}
 	}

--- a/modules/matches/Realtime/common/Common/src/commands/s2c.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/s2c.rs
@@ -110,11 +110,11 @@ impl S2CCommand {
 	pub fn get_trace_string(&self) -> String {
 		match self {
 			S2CCommand::Create(command) => format!("access({:?}), template({:?}) ", command.access_groups.0, command.template),
-			S2CCommand::Created(_) => "".to_string(),
+			S2CCommand::Created(_) => String::new(),
 			S2CCommand::SetField(command) => format!("{:?}", command.value),
 			S2CCommand::Event(command) => format!("{:?}", command.event),
-			S2CCommand::Delete(_) => "".to_string(),
-			S2CCommand::DeleteField(_) => "".to_string(),
+			S2CCommand::Delete(_) => String::new(),
+			S2CCommand::DeleteField(_) => String::new(),
 			S2CCommand::Forwarded(command) => format!("forward: member({:?}) command({:?})", command.creator, command.c2s.get_trace_string()),
 			S2CCommand::MemberConnected(command) => format!("member connected({:?})", command.member_id),
 		}

--- a/modules/matches/Realtime/common/Common/src/commands/types/create.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/create.rs
@@ -51,10 +51,7 @@ impl CreateGameObjectCommand {
 	}
 
 	pub fn decode(object_id: GameObjectId, input: &mut Cursor<&[u8]>) -> std::io::Result<Self> {
-		let template = input
-			.read_variable_u64()?
-			.try_into()
-			.map_err(|_| Error::new(ErrorKind::InvalidData, "could not cast into GameObjectTemplateId".to_string()))?;
+		let template = input.read_variable_u64()?.try_into().map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 		let access_groups = AccessGroups(input.read_variable_u64()?);
 		Ok(Self {
 			object_id,
@@ -66,7 +63,7 @@ impl CreateGameObjectCommand {
 
 impl C2SCreatedGameObjectCommand {
 	pub fn encode(&self, out: &mut Cursor<&mut [u8]>) -> std::io::Result<()> {
-		out.write_u8(if self.room_owner { 1 } else { 0 })?;
+		out.write_u8(u8::from(self.room_owner))?;
 		match &self.singleton_key {
 			None => out.write_variable_u64(0),
 			Some(buffer) => buffer.encode(out),

--- a/modules/matches/Realtime/common/Common/src/commands/types/event.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/event.rs
@@ -46,10 +46,7 @@ impl TargetEventCommand {
 	}
 
 	pub fn decode(object_id: GameObjectId, field_id: FieldId, input: &mut Cursor<&[u8]>) -> std::io::Result<Self> {
-		let target = input
-			.read_variable_u64()?
-			.try_into()
-			.map_err(|_| Error::new(ErrorKind::InvalidData, "could not cast into RoomMemberId".to_string()))?;
+		let target = input.read_variable_u64()?.try_into().map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 
 		Ok(Self {
 			target,

--- a/modules/matches/Realtime/common/Common/src/commands/types/forwarded.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/forwarded.rs
@@ -20,7 +20,7 @@ impl ForwardedCommand {
 		out.write_variable_u64(self.creator.into())?;
 		out.write_u8(
 			ToPrimitive::to_u8(&self.c2s.get_type_id())
-				.ok_or_else(|| Error::new(ErrorKind::InvalidData, "could not write CommandTypeId to u8".to_string()))?,
+				.ok_or_else(|| Error::new(ErrorKind::InvalidData, "could not write CommandTypeId to u8".to_owned()))?,
 		)?;
 		self.c2s.encode(out)
 	}

--- a/modules/matches/Realtime/common/Common/src/commands/types/long.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/long.rs
@@ -49,7 +49,7 @@ impl CompareAndSetLongCommand {
 	pub fn encode(&self, out: &mut Cursor<&mut [u8]>) -> std::io::Result<()> {
 		out.write_variable_i64(self.current)?;
 		out.write_variable_i64(self.new)?;
-		out.write_u8(if self.reset.is_some() { 1 } else { 0 })?;
+		out.write_u8(u8::from(self.reset.is_some()))?;
 		if let Some(reset_value) = &self.reset {
 			out.write_variable_i64(*reset_value)
 		} else {
@@ -61,6 +61,7 @@ impl CompareAndSetLongCommand {
 		let current = input.read_variable_i64()?;
 		let new = input.read_variable_i64()?;
 		let has_reset = input.read_u8()? == 1;
+		#[allow(clippy::if_then_some_else_none)]
 		let reset = if has_reset { Some(input.read_variable_i64()?) } else { None };
 		Ok(Self {
 			object_id,

--- a/modules/matches/Realtime/common/Common/src/commands/types/member_connected.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/member_connected.rs
@@ -2,7 +2,7 @@ use crate::protocol::codec::variable_int::{VariableIntReader, VariableIntWriter}
 use crate::room::RoomMemberId;
 use std::io::{Cursor, Error, ErrorKind};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MemberConnectedCommand {
 	pub member_id: RoomMemberId,
 }

--- a/modules/matches/Realtime/common/Common/src/commands/types/structure.rs
+++ b/modules/matches/Realtime/common/Common/src/commands/types/structure.rs
@@ -37,6 +37,7 @@ impl CompareAndSetStructureCommand {
 	}
 
 	pub fn decode(object_id: GameObjectId, field_id: FieldId, input: &mut Cursor<&[u8]>) -> std::io::Result<Self> {
+		#[allow(clippy::if_then_some_else_none)]
 		Ok(CompareAndSetStructureCommand {
 			object_id,
 			field_id,

--- a/modules/matches/Realtime/common/Common/src/network/channel.rs
+++ b/modules/matches/Realtime/common/Common/src/network/channel.rs
@@ -32,9 +32,9 @@ impl NetworkChannel {
 
 	pub fn recv(&mut self, now: Instant, buf: &mut [u8]) -> io::Result<usize> {
 		let result = self.socket.recv(buf);
-		if result.is_ok() {
+		if let Ok(read_bytes) = result {
 			self.recv_packet_count += 1;
-			self.recv_size += *result.as_ref().unwrap() as u64;
+			self.recv_size += read_bytes as u64;
 		}
 
 		if let Some(emulator) = self.emulator.as_mut() {

--- a/modules/matches/Realtime/common/Common/src/network/emulator.rs
+++ b/modules/matches/Realtime/common/Common/src/network/emulator.rs
@@ -76,14 +76,10 @@ impl NetworkLatencyEmulator {
 	pub fn get_in(&mut self, now: Instant) -> Option<Vec<u8>> {
 		match self.in_queue.peek() {
 			None => None,
-			Some(frame) => {
-				if now >= frame.time {
-					let frame = self.in_queue.pop().unwrap();
-					Some(frame.buffer)
-				} else {
-					None
-				}
-			}
+			Some(frame) => (now >= frame.time).then(|| {
+				let frame = self.in_queue.pop().unwrap();
+				frame.buffer
+			}),
 		}
 	}
 
@@ -107,14 +103,10 @@ impl NetworkLatencyEmulator {
 	pub fn get_out(&mut self, now: Instant) -> Option<(Vec<u8>, SocketAddr)> {
 		match self.out_queue.peek() {
 			None => None,
-			Some(data) => {
-				if now >= data.time {
-					let data = self.out_queue.pop().unwrap();
-					Some((data.buffer.clone(), data.addr.unwrap()))
-				} else {
-					None
-				}
-			}
+			Some(data) => (now >= data.time).then(|| {
+				let data = self.out_queue.pop().unwrap();
+				(data.buffer.clone(), data.addr.unwrap())
+			}),
 		}
 	}
 

--- a/modules/matches/Realtime/common/Common/src/protocol/codec/channel.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/codec/channel.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+use std::num::TryFromIntError;
 
 use thiserror::Error;
 
@@ -65,7 +66,7 @@ impl Channel {
 					input
 						.read_variable_u64()?
 						.try_into()
-						.map_err(|_| CommandChannelDecodeError::InputValueIsTooLarge)?,
+						.map_err(CommandChannelDecodeError::InputValueIsTooLarge)?,
 				),
 			),
 			_ => return Err(CommandChannelDecodeError::UnknownType(*channel_type)),
@@ -88,7 +89,7 @@ pub enum CommandChannelDecodeError {
 		source: CommandContextError,
 	},
 	#[error("InputValueIsTooLarge")]
-	InputValueIsTooLarge,
+	InputValueIsTooLarge(TryFromIntError),
 }
 
 #[cfg(test)]

--- a/modules/matches/Realtime/common/Common/src/protocol/codec/headers.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/codec/headers.rs
@@ -12,6 +12,7 @@ use crate::protocol::reliable::ack::header::AckHeader;
 use crate::protocol::reliable::retransmit::header::RetransmitHeader;
 
 impl Headers {
+	#[allow(clippy::map_err_ignore)]
 	pub fn decode_headers(input: &mut Cursor<&[u8]>) -> std::io::Result<Self> {
 		let mut headers = HeaderVec::new();
 		let count = input.read_variable_u64()?;

--- a/modules/matches/Realtime/common/Common/src/protocol/codec/variable_int.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/codec/variable_int.rs
@@ -31,7 +31,7 @@ impl VariableIntWriter for Cursor<&mut [u8]> {
 
 		if value < U8_MAX + 255 {
 			self.write_u8(U9_MARKER)?;
-			return self.write_u8((value - U8_MAX as u64) as u8);
+			return self.write_u8((value - U8_MAX) as u8);
 		};
 
 		if value < u64::from(u16::MAX) {
@@ -51,7 +51,7 @@ impl VariableIntWriter for Cursor<&mut [u8]> {
 
 		if value < u64::from(u32::MAX) * u64::from(u8::MAX) * u64::from(u8::MAX) {
 			self.write_u8(U48_MARKER)?;
-			return self.write_u48::<BigEndian>(value as u64);
+			return self.write_u48::<BigEndian>(value);
 		};
 
 		self.write_u8(U64_MARKER)?;
@@ -77,7 +77,7 @@ impl VariableIntReader for Cursor<&[u8]> {
 			U16_MARKER => u64::from(self.read_u16::<BigEndian>()?),
 			U24_MARKER => u64::from(self.read_u24::<BigEndian>()?),
 			U32_MARKER => u64::from(self.read_u32::<BigEndian>()?),
-			U48_MARKER => self.read_u48::<BigEndian>()? as u64,
+			U48_MARKER => self.read_u48::<BigEndian>()?,
 			U64_MARKER => self.read_u64::<BigEndian>()?,
 			_ => {
 				return Err(std::io::Error::new(
@@ -105,12 +105,12 @@ mod test {
 	fn test_u64() {
 		check_u64(U8_MAX - 1, 1);
 		check_u64(U8_MAX, 2);
-		check_u64(U8_MAX as u64 + 255 - 1, 2);
+		check_u64(U8_MAX + 255 - 1, 2);
 		check_u64(u64::from(u16::MAX - 1), 3);
 		check_u64(u64::from(u16::MAX) * u64::from(u8::MAX) - 1, 4);
 		check_u64(u64::from(u32::MAX - 1), 5);
 		check_u64(u64::from(u32::MAX) * u64::from(u8::MAX) - 1, 7);
-		check_u64((u64::MAX - 1) as u64, 9);
+		check_u64(u64::MAX - 1, 9);
 	}
 
 	#[test]

--- a/modules/matches/Realtime/common/Common/src/protocol/commands/input.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/commands/input.rs
@@ -164,7 +164,7 @@ mod tests {
 	use crate::room::owner::GameObjectOwner;
 
 	#[test]
-	pub fn test_clear_after_get_ready_commands() {
+	pub(crate) fn test_clear_after_get_ready_commands() {
 		let mut in_commands = InCommandsCollector::default();
 		let cmd_1 = create_test_command(Channel::ReliableUnordered, 1);
 		let frame = InFrame::new(1, Default::default(), [cmd_1.clone()].into_iter().collect());
@@ -174,7 +174,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn test_not_clear_after_collect() {
+	pub(crate) fn test_not_clear_after_collect() {
 		let mut in_commands = InCommandsCollector::default();
 		let cmd_1 = create_test_command(Channel::ReliableUnordered, 1);
 		let frame = InFrame::new(1, Default::default(), [cmd_1.clone()].into_iter().collect());
@@ -185,7 +185,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn test_unordered() {
+	pub(crate) fn test_unordered() {
 		let mut in_commands = InCommandsCollector::default();
 		let cmd_1 = create_test_command(Channel::ReliableUnordered, 1);
 		let cmd_2 = create_test_command(Channel::ReliableUnordered, 2);
@@ -195,7 +195,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn test_group_ordered() {
+	pub(crate) fn test_group_ordered() {
 		let mut in_commands = InCommandsCollector::default();
 
 		let cmd_1 = create_test_command(Channel::ReliableOrdered(ChannelGroup(1)), 1);
@@ -208,7 +208,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn test_group_ordered_when_different_group() {
+	pub(crate) fn test_group_ordered_when_different_group() {
 		let mut in_commands = InCommandsCollector::default();
 
 		let cmd_1 = create_test_command(Channel::ReliableOrdered(ChannelGroup(1)), 1);
@@ -219,7 +219,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn test_group_sequence() {
+	pub(crate) fn test_group_sequence() {
 		let mut in_commands = InCommandsCollector::default();
 
 		let cmd_1 = create_test_command(Channel::ReliableSequence(ChannelGroup(1), ChannelSequence(0)), 1);
@@ -238,7 +238,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn test_group_sequence_with_different_group() {
+	pub(crate) fn test_group_sequence_with_different_group() {
 		let mut in_commands = InCommandsCollector::default();
 
 		let cmd_1_a = create_test_command(Channel::ReliableSequence(ChannelGroup(1), ChannelSequence(0)), 1);

--- a/modules/matches/Realtime/common/Common/src/protocol/commands/output.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/commands/output.rs
@@ -90,7 +90,7 @@ mod tests {
 	use crate::protocol::frame::MAX_FRAME_SIZE;
 
 	#[test]
-	pub fn test_group_sequence() {
+	pub(crate) fn test_group_sequence() {
 		let mut output = OutCommandsCollector::default();
 		for _ in 0..3 {
 			output.add_command(
@@ -107,7 +107,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn should_split_commands_by_size() {
+	pub(crate) fn should_split_commands_by_size() {
 		let mut output = OutCommandsCollector::default();
 		for _i in 0..MAX_FRAME_SIZE {
 			output.add_command(

--- a/modules/matches/Realtime/common/Common/src/protocol/disconnect/command.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/disconnect/command.rs
@@ -54,7 +54,7 @@ impl DisconnectByCommand {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-pub struct DisconnectHeader {}
+pub struct DisconnectHeader;
 
 #[cfg(test)]
 mod tests {
@@ -64,7 +64,7 @@ mod tests {
 	use crate::protocol::frame::output::OutFrame;
 
 	#[test]
-	pub fn should_disconnect() {
+	pub(crate) fn should_disconnect() {
 		let mut self_handler = DisconnectByCommand::default();
 		let mut remote_handler = DisconnectByCommand::default();
 
@@ -85,7 +85,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn should_not_disconnect() {
+	pub(crate) fn should_not_disconnect() {
 		let mut handler = DisconnectByCommand::default();
 		let mut frame = OutFrame::new(10);
 		handler.build_frame(&mut frame);

--- a/modules/matches/Realtime/common/Common/src/protocol/disconnect/timeout.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/disconnect/timeout.rs
@@ -34,7 +34,7 @@ mod tests {
 	///
 	/// После запуска - канал некоторые время считается открытым
 	///
-	pub fn should_not_disconnect_when_start() {
+	pub(crate) fn should_not_disconnect_when_start() {
 		let now = Instant::now();
 		let handler = DisconnectByTimeout::new(now);
 		assert!(!handler.disconnected(now));
@@ -44,7 +44,7 @@ mod tests {
 	/// Разрыв связи через timeout после старта, если не было ни одного фрейма
 	///
 	#[test]
-	pub fn should_disconnect_after_timeout() {
+	pub(crate) fn should_disconnect_after_timeout() {
 		let now = Instant::now();
 		let handler = DisconnectByTimeout::new(now);
 		assert!(handler.disconnected(now.add(DisconnectByTimeout::TIMEOUT).add(Duration::from_millis(1))));
@@ -54,7 +54,7 @@ mod tests {
 	/// Если был пакет - то канал не закрыт определенное время после этого
 	///
 	#[test]
-	pub fn should_not_disconnect_when_not_timeout_after_frame() {
+	pub(crate) fn should_not_disconnect_when_not_timeout_after_frame() {
 		let now = Instant::now();
 		let mut handler = DisconnectByTimeout::new(now);
 		handler.on_frame_received(now);
@@ -65,7 +65,7 @@ mod tests {
 	/// Если был пакет - то канал закрыт после таймаута
 	///
 	#[test]
-	pub fn should_disconnect_when_not_timeout_after_frame() {
+	pub(crate) fn should_disconnect_when_not_timeout_after_frame() {
 		let now = Instant::now();
 		let mut handler = DisconnectByTimeout::new(now);
 		handler.on_frame_received(now);

--- a/modules/matches/Realtime/common/Common/src/protocol/mod.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/mod.rs
@@ -109,7 +109,7 @@ impl Protocol {
 			|| self.disconnect_by_command.contains_self_data()
 			|| self.keep_alive.contains_self_data(now);
 
-		if contains_data {
+		contains_data.then(|| {
 			let mut frame = OutFrame::new(self.next_frame_id);
 			self.next_frame_id += 1;
 
@@ -119,10 +119,8 @@ impl Protocol {
 			self.rtt.build_frame(&mut frame, now);
 			self.keep_alive.build_frame(&mut frame, now);
 			self.retransmitter.build_frame(&frame, now);
-			Some(frame)
-		} else {
-			None
-		}
+			frame
+		})
 	}
 
 	///

--- a/modules/matches/Realtime/common/Common/src/protocol/others/keep_alive.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/others/keep_alive.rs
@@ -36,14 +36,14 @@ mod tests {
 	use crate::protocol::others::keep_alive::KeepAlive;
 
 	#[test]
-	pub fn should_send_first_time() {
+	pub(crate) fn should_send_first_time() {
 		let handler = KeepAlive::default();
 		let now = Instant::now();
 		assert!(handler.contains_self_data(now));
 	}
 
 	#[test]
-	pub fn should_timeout_after_send() {
+	pub(crate) fn should_timeout_after_send() {
 		let mut handler = KeepAlive::default();
 		let now = Instant::now();
 		let mut frame = OutFrame::new(1);

--- a/modules/matches/Realtime/common/Common/src/protocol/others/member_id.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/others/member_id.rs
@@ -13,10 +13,7 @@ pub struct MemberAndRoomId {
 impl MemberAndRoomId {
 	pub(crate) fn decode(input: &mut Cursor<&[u8]>) -> std::io::Result<Self> {
 		Ok(Self {
-			member_id: input
-				.read_variable_u64()?
-				.try_into()
-				.map_err(|_| std::io::Error::new(InvalidData, "member_id is too large".to_string()))?,
+			member_id: input.read_variable_u64()?.try_into().map_err(|e| std::io::Error::new(InvalidData, e))?,
 			room_id: input.read_variable_u64()?,
 		})
 	}

--- a/modules/matches/Realtime/common/Common/src/protocol/others/rtt.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/others/rtt.rs
@@ -76,13 +76,10 @@ impl RoundTripTime {
 	#[allow(clippy::cast_possible_truncation)]
 	#[must_use]
 	pub fn get_rtt(&self) -> Option<Duration> {
-		if self.rtt.is_full() {
+		self.rtt.is_full().then(|| {
 			let sum_rtt: Duration = self.rtt.iter().sum();
-			let average_rtt = sum_rtt.div(self.rtt.len() as u32);
-			Some(average_rtt)
-		} else {
-			None
-		}
+			sum_rtt.div(self.rtt.len() as u32)
+		})
 	}
 
 	#[allow(clippy::cast_possible_truncation)]
@@ -145,7 +142,7 @@ mod tests {
 	/// Тестируем обмен между двумя handler-ми.
 	/// После обмена должно быть определено rtt.
 	///
-	pub fn should_calculate_rtt() {
+	pub(crate) fn should_calculate_rtt() {
 		let mut handler_a = RoundTripTime::new(Instant::now());
 		let mut handler_b = RoundTripTime::new(Instant::now());
 
@@ -169,7 +166,7 @@ mod tests {
 	///
 	/// Для retransmit фреймов операции получения response должны быть игнорированы
 	///
-	pub fn should_ignore_retransmit_frame_when_receive_response() {
+	pub(crate) fn should_ignore_retransmit_frame_when_receive_response() {
 		let mut handler = RoundTripTime::new(Instant::now());
 		let now = Instant::now();
 		let mut frame = InFrame::new(10, Default::default(), Default::default());
@@ -186,7 +183,7 @@ mod tests {
 	///
 	/// Для retransmit фреймов операции получения request должны быть игнорированы
 	///
-	pub fn should_ignore_retransmit_frame_when_receive_request() {
+	pub(crate) fn should_ignore_retransmit_frame_when_receive_request() {
 		let mut handler = RoundTripTime::new(Instant::now());
 		let now = Instant::now();
 
@@ -212,7 +209,7 @@ mod tests {
 	/// - учитываем что для расчета среднего rtt количество измерение должно быть больше определенного значения
 	///
 	#[test]
-	pub fn should_calculate_rtt_average() {
+	pub(crate) fn should_calculate_rtt_average() {
 		let mut handler = RoundTripTime::new(Instant::now());
 		for i in 0..AVERAGE_RTT_MIN_LEN {
 			let mut frame = InFrame::new(10, Default::default(), Default::default());
@@ -230,7 +227,7 @@ mod tests {
 	/// Проверяем лимит на максимальный размер измерений
 	///
 	#[test]
-	pub fn should_limit_on_length_rtt() {
+	pub(crate) fn should_limit_on_length_rtt() {
 		let mut handler = RoundTripTime::new(Instant::now());
 		for i in 0..2 * AVERAGE_RTT_MIN_LEN {
 			let mut frame = InFrame::new(10, Default::default(), Default::default());

--- a/modules/matches/Realtime/common/Common/src/protocol/reliable/ack/header.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/reliable/ack/header.rs
@@ -53,18 +53,17 @@ impl AckHeader {
 
 #[cfg(test)]
 mod tests {
-	use crate::protocol::frame::FrameId;
 	use crate::protocol::reliable::ack::header::AckHeader;
 
 	#[test]
 	///
 	/// Проверяем сохранение списка `frame_id`
 	///
-	pub fn should_store_frame_id() {
+	pub(crate) fn should_store_frame_id() {
 		let mut header = AckHeader::default();
 		let originals = vec![1, 2, 3, 4, 7, 9, 15];
 		for i in &originals {
-			header.add_frame_id(*i as FrameId);
+			header.add_frame_id(*i);
 		}
 
 		let actual = header.get_frames().as_slice();

--- a/modules/matches/Realtime/common/Common/src/protocol/reliable/replay_protection.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/reliable/replay_protection.rs
@@ -82,7 +82,7 @@ mod tests {
 		let frame_a = InFrame::new(1000 + FrameReplayProtection::BUFFER_SIZE as u64, Default::default(), Default::default());
 		let frame_b = InFrame::new(10, Default::default(), Default::default());
 		assert!(!protection.set_and_check(&frame_a).unwrap());
-		assert!(protection.set_and_check(&frame_b).is_err());
+		protection.set_and_check(&frame_b).unwrap_err();
 	}
 
 	#[test]

--- a/modules/matches/Realtime/common/Common/src/protocol/reliable/retransmit/mod.rs
+++ b/modules/matches/Realtime/common/Common/src/protocol/reliable/retransmit/mod.rs
@@ -93,6 +93,7 @@ impl Retransmit {
 	/// Получить фрейм для повторной отправки (если такой есть)
 	/// - метод необходимо вызывать пока результат Some
 	///
+	#[allow(clippy::unwrap_in_result)]
 	pub fn get_retransmit_frame(&mut self, now: Instant, retransmit_frame_id: FrameId) -> Option<OutFrame> {
 		loop {
 			match self.frames.front() {

--- a/modules/matches/Realtime/common/Common/src/room/mod.rs
+++ b/modules/matches/Realtime/common/Common/src/room/mod.rs
@@ -33,7 +33,7 @@ impl From<MemberPrivateKey> for Vec<u8> {
 
 impl From<&[u8]> for MemberPrivateKey {
 	fn from(source: &[u8]) -> MemberPrivateKey {
-		let mut key = [0u8; 32];
+		let mut key = [0_u8; 32];
 		let len = min(source.len(), key.len());
 		key[0..len].copy_from_slice(source);
 		MemberPrivateKey(key)

--- a/modules/matches/Realtime/common/Common/src/room/object.rs
+++ b/modules/matches/Realtime/common/Common/src/room/object.rs
@@ -40,17 +40,10 @@ impl GameObjectId {
 	}
 	pub fn decode(input: &mut Cursor<&[u8]>) -> std::io::Result<Self> {
 		Ok(GameObjectId {
-			id: input
-				.read_variable_u64()?
-				.try_into()
-				.map_err(|_| Error::new(ErrorKind::InvalidData, "could not cast to GameObjectId".to_string()))?,
+			id: input.read_variable_u64()?.try_into().map_err(|e| Error::new(ErrorKind::InvalidData, e))?,
 			owner: match input.read_variable_i64()? {
 				-1 => GameObjectOwner::Room,
-				member_id => GameObjectOwner::Member(
-					member_id
-						.try_into()
-						.map_err(|_| Error::new(ErrorKind::InvalidData, "could not cast i32 to RoomMemberId".to_string()))?,
-				),
+				member_id => GameObjectOwner::Member(member_id.try_into().map_err(|e| Error::new(ErrorKind::InvalidData, e))?),
 			},
 		})
 	}

--- a/modules/matches/Realtime/common/Common/src/trace_collector.rs
+++ b/modules/matches/Realtime/common/Common/src/trace_collector.rs
@@ -49,7 +49,7 @@ impl TracerCollector {
 		if filter >= *event.metadata().level() {
 			let mut visitor = ValueVisitor::new("message");
 			event.record(&mut visitor);
-			let message = visitor.result.unwrap_or_else(|| "".to_string());
+			let message = visitor.result.unwrap_or_default();
 			let level = *event.metadata().level();
 			let message = format!(
 				"{} in {}:{}",
@@ -80,7 +80,7 @@ pub struct ValueVisitor {
 impl ValueVisitor {
 	pub fn new<S: AsRef<str>>(name: S) -> Self {
 		Self {
-			name: name.as_ref().to_string(),
+			name: name.as_ref().to_owned(),
 			result: None,
 		}
 	}

--- a/modules/matches/Realtime/common/Common/tests/stub/mod.rs
+++ b/modules/matches/Realtime/common/Common/tests/stub/mod.rs
@@ -44,13 +44,10 @@ impl Channel {
 
 	#[must_use]
 	pub fn allow(&self, position: u64) -> bool {
-		let find = self.reliable_percents.iter().find_map(|(range, percent)| {
-			if range.contains(&position) {
-				Some(OsRng.gen_bool(*percent))
-			} else {
-				None
-			}
-		});
+		let find = self
+			.reliable_percents
+			.iter()
+			.find_map(|(range, percent)| range.contains(&position).then(|| OsRng.gen_bool(*percent)));
 		find.unwrap_or(true)
 	}
 }

--- a/modules/matches/Realtime/common/Macro/src/enum_match_predicates.rs
+++ b/modules/matches/Realtime/common/Macro/src/enum_match_predicates.rs
@@ -7,7 +7,7 @@ use syn::{Data, DataEnum};
 ///
 /// Генерация метода для поиска конкретного элемента enum в коллекции
 ///
-pub fn do_enum_match_predicates(input: TokenStream) -> TokenStream {
+pub(crate) fn do_enum_match_predicates(input: TokenStream) -> TokenStream {
 	let ast: syn::DeriveInput = syn::parse(input).unwrap();
 	let name = &ast.ident;
 	let enum_data: DataEnum = match ast.data {

--- a/modules/matches/Realtime/server/src/agones/mod.rs
+++ b/modules/matches/Realtime/server/src/agones/mod.rs
@@ -94,14 +94,14 @@ async fn notify_registry(gs: &GameServer, state: RelayState) -> Result<(), Regis
 	let status = gs
 		.status
 		.as_ref()
-		.ok_or_else(|| RegistryError::InvalidGameServerStatus("could not find status in GameServer".to_string()))?;
+		.ok_or_else(|| RegistryError::InvalidGameServerStatus("could not find status in GameServer".to_owned()))?;
 	let host = status.address;
 	let port = status
 		.ports
 		.iter()
 		.find(|p| p.name == "default")
 		.map(|p| p.port)
-		.ok_or_else(|| RegistryError::InvalidGameServerStatus("could not find port default in GameServer Status".to_string()))?;
+		.ok_or_else(|| RegistryError::InvalidGameServerStatus("could not find port default in GameServer Status".to_owned()))?;
 
 	let addrs = RelayAddrs {
 		game: Some(Addr {

--- a/modules/matches/Realtime/server/src/agones/proto.rs
+++ b/modules/matches/Realtime/server/src/agones/proto.rs
@@ -1,3 +1,11 @@
 pub mod registry {
+	#![allow(
+		clippy::empty_structs_with_brackets,
+		clippy::derive_partial_eq_without_eq,
+		clippy::wildcard_imports,
+		clippy::return_self_not_must_use,
+		clippy::clone_on_ref_ptr,
+		clippy::similar_names
+	)]
 	tonic::include_proto!("cheetah.matches.registry.internal");
 }

--- a/modules/matches/Realtime/server/src/bin/service.rs
+++ b/modules/matches/Realtime/server/src/bin/service.rs
@@ -41,7 +41,7 @@ mod tests {
 		let env_var = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
 		env::set_var(&env_var, "plugin_1;plugin_2");
 		assert_eq!(
-			FnvHashSet::<String>::from_iter(["plugin_1".to_string(), "plugin_2".to_string()]),
+			FnvHashSet::<String>::from_iter(["plugin_1".to_owned(), "plugin_2".to_owned()]),
 			get_plugin_names(&env_var)
 		);
 		env::remove_var(&env_var);

--- a/modules/matches/Realtime/server/src/debug/proto.rs
+++ b/modules/matches/Realtime/server/src/debug/proto.rs
@@ -1,6 +1,23 @@
 pub mod admin {
+	#![allow(
+		clippy::empty_structs_with_brackets,
+		clippy::derive_partial_eq_without_eq,
+		clippy::wildcard_imports,
+		clippy::return_self_not_must_use,
+		clippy::clone_on_ref_ptr,
+		clippy::similar_names
+	)]
 	tonic::include_proto!("cheetah.matches.realtime.admin");
 }
+
 pub mod shared {
+	#![allow(
+		clippy::empty_structs_with_brackets,
+		clippy::derive_partial_eq_without_eq,
+		clippy::wildcard_imports,
+		clippy::return_self_not_must_use,
+		clippy::clone_on_ref_ptr,
+		clippy::similar_names
+	)]
 	tonic::include_proto!("cheetah.matches.realtime.shared");
 }

--- a/modules/matches/Realtime/server/src/debug/tracer/filter.rs
+++ b/modules/matches/Realtime/server/src/debug/tracer/filter.rs
@@ -58,21 +58,21 @@ impl TracedBothDirectionCommand {
 			TracedBothDirectionCommand::S2C(_) => RuleCommandDirection::S2C,
 		}
 	}
-	pub fn get_field_type(&self) -> Option<FieldType> {
+	pub(crate) fn get_field_type(&self) -> Option<FieldType> {
 		match self {
 			TracedBothDirectionCommand::C2S(command) => command.get_field_type(),
 			TracedBothDirectionCommand::S2C(command) => command.get_field_type(),
 		}
 	}
 
-	pub fn get_field_id(&self) -> Option<FieldId> {
+	pub(crate) fn get_field_id(&self) -> Option<FieldId> {
 		match self {
 			TracedBothDirectionCommand::C2S(command) => command.get_field_id(),
 			TracedBothDirectionCommand::S2C(command) => command.get_field_id(),
 		}
 	}
 
-	pub fn get_object_id(&self) -> Option<GameObjectId> {
+	pub(crate) fn get_object_id(&self) -> Option<GameObjectId> {
 		match self {
 			TracedBothDirectionCommand::C2S(command) => command.get_object_id(),
 			TracedBothDirectionCommand::S2C(command) => command.get_object_id(),

--- a/modules/matches/Realtime/server/src/debug/tracer/mod.rs
+++ b/modules/matches/Realtime/server/src/debug/tracer/mod.rs
@@ -105,7 +105,7 @@ impl Session {
 	///
 	/// Максимальное число сохраненных команд в сессии
 	///
-	pub const BUFFER_LIMIT: usize = 65000;
+	pub(crate) const BUFFER_LIMIT: usize = 65000;
 
 	#[cfg(not(test))]
 	fn now() -> f64 {
@@ -121,7 +121,7 @@ impl Session {
 	/// Сохранение сетевой команды
 	/// - учитывается ограничение на размер буфера команд
 	///
-	pub fn collect(&mut self, template: Option<GameObjectTemplateId>, member_id: RoomMemberId, network_command: TracedBothDirectionCommand) {
+	pub(crate) fn collect(&mut self, template: Option<GameObjectTemplateId>, member_id: RoomMemberId, network_command: TracedBothDirectionCommand) {
 		let collected_command = TracedCommand {
 			time: Session::now(),
 			template,
@@ -156,8 +156,7 @@ impl Session {
 	///
 	/// Сохранить фильтр в сессии и применить его для уже собранных команд
 	///
-	pub fn apply_filter(&mut self, filter: Filter) {
-		let filter = filter;
+	pub(crate) fn apply_filter(&mut self, filter: Filter) {
 		self.filtered_commands = self.commands.iter().filter(|c| filter.filter(c)).cloned().collect();
 		self.filter = Some(filter);
 	}
@@ -438,7 +437,7 @@ pub mod tests {
 		let mut tracer = CommandTracerSessions::default();
 		let session_id = tracer.create_session();
 		let (sender, receiver) = std::sync::mpsc::channel();
-		tracer.execute_task(TracerSessionCommand::SetFilter(session_id, "(user=55)".to_string(), sender));
+		tracer.execute_task(TracerSessionCommand::SetFilter(session_id, "(user=55)".to_owned(), sender));
 		match receiver.try_recv() {
 			Ok(result) => match result {
 				Ok(_) => {}
@@ -453,7 +452,7 @@ pub mod tests {
 		let mut tracer = CommandTracerSessions::default();
 		let session_id = tracer.create_session();
 		let (sender, receiver) = std::sync::mpsc::channel();
-		tracer.execute_task(TracerSessionCommand::SetFilter(session_id, "(8=55)".to_string(), sender));
+		tracer.execute_task(TracerSessionCommand::SetFilter(session_id, "(8=55)".to_owned(), sender));
 		match receiver.try_recv() {
 			Ok(result) => {
 				if result.is_ok() {

--- a/modules/matches/Realtime/server/src/grpc/proto.rs
+++ b/modules/matches/Realtime/server/src/grpc/proto.rs
@@ -1,7 +1,23 @@
 pub mod shared {
+	#![allow(
+		clippy::empty_structs_with_brackets,
+		clippy::derive_partial_eq_without_eq,
+		clippy::wildcard_imports,
+		clippy::return_self_not_must_use,
+		clippy::clone_on_ref_ptr,
+		clippy::similar_names
+	)]
 	tonic::include_proto!("cheetah.matches.realtime.shared");
 }
 
 pub mod internal {
+	#![allow(
+		clippy::empty_structs_with_brackets,
+		clippy::derive_partial_eq_without_eq,
+		clippy::wildcard_imports,
+		clippy::return_self_not_must_use,
+		clippy::clone_on_ref_ptr,
+		clippy::similar_names
+	)]
 	tonic::include_proto!("cheetah.matches.realtime.internal");
 }

--- a/modules/matches/Realtime/server/src/room/command/compare_and_set.rs
+++ b/modules/matches/Realtime/server/src/room/command/compare_and_set.rs
@@ -47,6 +47,7 @@ impl ServerCommandExecutor for CompareAndSetStructureCommand {
 	}
 }
 
+#[allow(clippy::map_err_ignore)]
 pub fn perform_compare_and_set(
 	room: &mut Room,
 	member_id: RoomMemberId,
@@ -86,7 +87,7 @@ pub fn perform_compare_and_set(
 			}
 			Some(reset_value) => {
 				cls.insert((object_id, field_id, field_type), reset_value.clone())
-					.map_err(|_| ServerCommandError::Error("CompareAndSetCleaners overflow".to_string()))?;
+					.map_err(|_| ServerCommandError::Error("CompareAndSetCleaners overflow".to_owned()))?;
 			}
 		}
 	}

--- a/modules/matches/Realtime/server/src/room/command/create.rs
+++ b/modules/matches/Realtime/server/src/room/command/create.rs
@@ -11,7 +11,7 @@ impl ServerCommandExecutor for CreateGameObjectCommand {
 		let member = room.get_member(&member_id)?;
 
 		if self.object_id.id == 0 {
-			return Err(ServerCommandError::Error("0 is forbidden for game object id".to_string()));
+			return Err(ServerCommandError::Error("0 is forbidden for game object id".to_owned()));
 		}
 
 		let groups = self.access_groups;

--- a/modules/matches/Realtime/server/src/room/command/created.rs
+++ b/modules/matches/Realtime/server/src/room/command/created.rs
@@ -71,7 +71,7 @@ mod tests {
 	/// - Команда не должна отсылаться обратно пользователю
 	///
 	#[test]
-	pub fn should_send_commands() {
+	pub(crate) fn should_send_commands() {
 		let (mut room, object_id, member1, member2) = setup_two_players();
 		room.test_mark_as_connected(member1).unwrap();
 		room.test_mark_as_connected(member2).unwrap();
@@ -98,7 +98,7 @@ mod tests {
 	/// Команда должна отметить объект как загруженный
 	///
 	#[test]
-	pub fn should_switch_object_to_created_state() {
+	pub(crate) fn should_switch_object_to_created_state() {
 		let (mut room, object_id, member1, _) = setup_two_players();
 		let command = C2SCreatedGameObjectCommand {
 			object_id,
@@ -117,7 +117,7 @@ mod tests {
 	/// Такого быть не должно, однако проверить стоит, так как команду могут послать умышленно.
 	///
 	#[test]
-	pub fn should_dont_send_command_if_object_already_created() {
+	pub(crate) fn should_dont_send_command_if_object_already_created() {
 		let (mut room, object_id, member1, _) = setup_two_players();
 		let object = room.get_object_mut(object_id).unwrap();
 		object.created = true;
@@ -136,7 +136,7 @@ mod tests {
 	/// Если создается объект с owner = room, то его id должен сменится на id с owner = room
 	///
 	#[test]
-	pub fn should_convert_object_to_room_object() {
+	pub(crate) fn should_convert_object_to_room_object() {
 		let (mut room, member_id, access_groups) = setup_one_player();
 		let member_object_id = GameObjectId::new(100, GameObjectOwner::Member(member_id));
 		let create_command = CreateGameObjectCommand {
@@ -154,7 +154,7 @@ mod tests {
 		created_command.execute(&mut room, member_id).unwrap();
 
 		// старого объекта уже не должно быть
-		assert!(room.get_object_mut(member_object_id).is_err());
+		room.get_object_mut(member_object_id).unwrap_err();
 
 		let (_object_id, object) = room.objects.first().unwrap();
 		// это именно тот объект, который мы создали?
@@ -175,7 +175,7 @@ mod tests {
 	/// Не должно быть двух объектов с владельцем Room с одним `singleton_key`
 	///
 	#[test]
-	pub fn should_dont_create_more_one_object_with_one_singleton_key() {
+	pub(crate) fn should_dont_create_more_one_object_with_one_singleton_key() {
 		let (mut room, member_id, access_groups) = setup_one_player();
 
 		let singleton_key = Some(BinaryValue::from([1, 2, 3].as_slice()));

--- a/modules/matches/Realtime/server/src/room/command/delete.rs
+++ b/modules/matches/Realtime/server/src/room/command/delete.rs
@@ -72,7 +72,7 @@ mod tests {
 
 		assert!(matches!(
 			command.execute(&mut room, member_b),
-			Err(ServerCommandError::MemberNotOwnerGameObject { object_id: _, member_id: _ })
+			Err(ServerCommandError::MemberNotOwnerGameObject { .. })
 		));
 		assert!(matches!(room.get_object_mut(object_id), Ok(_)));
 		assert!(matches!(room.test_out_commands.pop_back(), None));

--- a/modules/matches/Realtime/server/src/room/command/event.rs
+++ b/modules/matches/Realtime/server/src/room/command/event.rs
@@ -62,7 +62,7 @@ mod tests {
 	use crate::room::Room;
 
 	#[test]
-	pub fn should_send_event() {
+	pub(crate) fn should_send_event() {
 		let (mut room, member_id, access_groups) = setup_one_player();
 		let object = room.test_create_object_with_not_created_state(GameObjectOwner::Member(member_id), access_groups);
 		object.created = true;
@@ -80,7 +80,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn should_send_event_to_member() {
+	pub(crate) fn should_send_event_to_member() {
 		let template = RoomTemplate::default();
 		let access_groups = AccessGroups(10);
 

--- a/modules/matches/Realtime/server/src/room/command/field.rs
+++ b/modules/matches/Realtime/server/src/room/command/field.rs
@@ -62,7 +62,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn should_delete_field() {
+	pub(crate) fn should_delete_field() {
 		let mut object = GameObject::new(GameObjectId::default(), 0, Default::default(), false);
 
 		object.set_field(1, [1, 2, 3].as_ref()).unwrap();

--- a/modules/matches/Realtime/server/src/room/command/forwarded.rs
+++ b/modules/matches/Realtime/server/src/room/command/forwarded.rs
@@ -10,7 +10,7 @@ impl ServerCommandExecutor for ForwardedCommand {
 		if let Some(member) = room.members.get(&member_id) {
 			if !member.template.super_member {
 				return Err(ServerCommandError::ForwardedCommandPermissionDenied {
-					msg: "only super members are allowed to send ForwardedCommand".to_string(),
+					msg: "only super members are allowed to send ForwardedCommand".to_owned(),
 					sender_member_id: member_id,
 					creator_member_id: self.creator,
 				});
@@ -22,7 +22,7 @@ impl ServerCommandExecutor for ForwardedCommand {
 		// check that sender and creator are different
 		if member_id == self.creator {
 			return Err(ServerCommandError::ForwardedCommandPermissionDenied {
-				msg: "ForwardedCommand sender and creator should be different".to_string(),
+				msg: "ForwardedCommand sender and creator should be different".to_owned(),
 				sender_member_id: member_id,
 				creator_member_id: self.creator,
 			});
@@ -32,7 +32,7 @@ impl ServerCommandExecutor for ForwardedCommand {
 			// check that command creator is not a super member
 			if member.template.super_member {
 				return Err(ServerCommandError::ForwardedCommandPermissionDenied {
-					msg: "only non super members commands can be forwarded".to_string(),
+					msg: "only non super members commands can be forwarded".to_owned(),
 					sender_member_id: member_id,
 					creator_member_id: self.creator,
 				});
@@ -67,7 +67,7 @@ mod tests {
 		};
 		assert_eq!(
 			ForwardedCommandPermissionDenied {
-				msg: "only super members are allowed to send ForwardedCommand".to_string(),
+				msg: "only super members are allowed to send ForwardedCommand".to_owned(),
 				sender_member_id: member_1,
 				creator_member_id: 0,
 			},
@@ -84,7 +84,7 @@ mod tests {
 		};
 		assert_eq!(
 			ForwardedCommandPermissionDenied {
-				msg: "only non super members commands can be forwarded".to_string(),
+				msg: "only non super members commands can be forwarded".to_owned(),
 				sender_member_id: super_member_1,
 				creator_member_id: super_member_2,
 			},
@@ -101,7 +101,7 @@ mod tests {
 		};
 		assert_eq!(
 			ForwardedCommandPermissionDenied {
-				msg: "ForwardedCommand sender and creator should be different".to_string(),
+				msg: "ForwardedCommand sender and creator should be different".to_owned(),
 				sender_member_id: super_member_1,
 				creator_member_id: super_member_1,
 			},
@@ -141,7 +141,7 @@ mod tests {
 		if let Err(e) = command.execute(&mut room, super_member_1) {
 			panic!("{:?}", e)
 		}
-		assert!(!room.members.get(&member_1).unwrap().attached);
+		assert!(!room.members[&member_1].attached);
 	}
 
 	fn setup() -> (Room, RoomMemberId, RoomMemberId, RoomMemberId) {

--- a/modules/matches/Realtime/server/src/room/command/mod.rs
+++ b/modules/matches/Realtime/server/src/room/command/mod.rs
@@ -130,7 +130,7 @@ mod tests {
 	use crate::room::template::config::{MemberTemplate, RoomTemplate};
 	use crate::room::Room;
 
-	pub fn setup_two_players() -> (Room, GameObjectId, RoomMemberId, RoomMemberId) {
+	pub(crate) fn setup_two_players() -> (Room, GameObjectId, RoomMemberId, RoomMemberId) {
 		let template = RoomTemplate::default();
 		let access_groups = AccessGroups(0b11);
 		let mut room = Room::from_template(template);
@@ -142,7 +142,7 @@ mod tests {
 		(room, object_id, member_1, member_2)
 	}
 
-	pub fn setup_one_player() -> (Room, RoomMemberId, AccessGroups) {
+	pub(crate) fn setup_one_player() -> (Room, RoomMemberId, AccessGroups) {
 		let template = RoomTemplate::default();
 		let access_groups = AccessGroups(10);
 		let mut room = Room::from_template(template);

--- a/modules/matches/Realtime/server/src/room/command/room.rs
+++ b/modules/matches/Realtime/server/src/room/command/room.rs
@@ -1,4 +1,5 @@
 use cheetah_matches_realtime_common::room::RoomMemberId;
+use std::rc::Rc;
 
 use crate::room::command::ServerCommandError;
 use crate::room::object::CreateCommandsCollector;
@@ -8,7 +9,7 @@ pub fn attach_to_room(room: &mut Room, member_id: RoomMemberId) -> Result<(), Se
 	let member = room.get_member_mut(&member_id)?;
 	member.attached = true;
 	let access_group = member.template.groups;
-	let command_collector_rc = room.tmp_command_collector.clone();
+	let command_collector_rc = Rc::clone(&room.tmp_command_collector);
 	let mut command_collector = (*command_collector_rc).borrow_mut();
 	command_collector.clear();
 	room.objects
@@ -46,7 +47,7 @@ mod tests {
 	use crate::room::Room;
 
 	#[test]
-	pub fn should_load_object_when_attach_to_room() {
+	pub(crate) fn should_load_object_when_attach_to_room() {
 		let template = RoomTemplate::default();
 		let mut room = Room::from_template(template);
 		let groups_a = AccessGroups(0b100);

--- a/modules/matches/Realtime/server/src/room/command/structure.rs
+++ b/modules/matches/Realtime/server/src/room/command/structure.rs
@@ -19,7 +19,7 @@ mod tests {
 	const FIELD_ID: u16 = 100;
 
 	#[test]
-	pub fn should_set_structure() {
+	pub(crate) fn should_set_structure() {
 		let template = RoomTemplate::default();
 		let mut room = Room::from_template(template);
 		let access_groups = AccessGroups(10);
@@ -98,13 +98,13 @@ mod tests {
 	}
 
 	#[test]
-	pub fn should_send_command_to_all_when_owner_sets_structure_field() {
+	pub(crate) fn should_send_command_to_all_when_owner_sets_structure_field() {
 		let (mut room, member1, member2, object_id) = init_set_structure_test();
 		run_set_structure_test(&mut room, member1, member2, object_id, member1);
 	}
 
 	#[test]
-	pub fn should_send_command_to_all_when_non_owner_sets_structure_field() {
+	pub(crate) fn should_send_command_to_all_when_non_owner_sets_structure_field() {
 		let (mut room, member1, member2, object_id) = init_set_structure_test();
 		run_set_structure_test(&mut room, member1, member2, object_id, member2);
 	}

--- a/modules/matches/Realtime/server/src/room/object.rs
+++ b/modules/matches/Realtime/server/src/room/object.rs
@@ -81,6 +81,7 @@ impl GameObject {
 		self.set_field_wrapped(field_id, field_value)
 	}
 
+	#[allow(clippy::map_err_ignore)]
 	pub fn set_field_wrapped(&mut self, field_id: FieldId, value: FieldValue) -> Result<(), GameObjectError> {
 		let field_type = value.field_type();
 		self.fields
@@ -99,6 +100,7 @@ impl GameObject {
 		self.compare_and_set_owners.get(field_id)
 	}
 
+	#[allow(clippy::map_err_ignore)]
 	pub fn set_compare_and_set_owner(&mut self, field_id: FieldId, value: RoomMemberId) -> Result<(), GameObjectError> {
 		self.compare_and_set_owners
 			.insert(field_id, value)
@@ -163,7 +165,7 @@ mod tests {
 	/// Проверяем что все типы данных преобразованы в команды
 	///
 	#[test]
-	pub fn should_collect_command() {
+	pub(crate) fn should_collect_command() {
 		let id = GameObjectId::new(1, GameObjectOwner::Room);
 		let mut object = GameObject::new(id, 55, AccessGroups(63), true);
 		object.set_field(1, 100).unwrap();
@@ -234,7 +236,7 @@ mod tests {
 	/// Для несозданного объекта не должно быть команды Created
 	///
 	#[test]
-	pub fn should_collect_command_for_not_created_object() {
+	pub(crate) fn should_collect_command_for_not_created_object() {
 		let id = GameObjectId::new(1, GameObjectOwner::Room);
 		let mut object = GameObject::new(id, 0, Default::default(), false);
 		object.set_field(1, 100).unwrap();
@@ -260,7 +262,7 @@ mod tests {
 	}
 
 	#[test]
-	pub fn should_update_structure() {
+	pub(crate) fn should_update_structure() {
 		let mut object = GameObject::new(GameObjectId::default(), 0, Default::default(), false);
 		object.set_field(1, [1, 2, 3].as_ref()).unwrap();
 		object.set_field(1, [4, 5, 6, 7].as_ref()).unwrap();

--- a/modules/matches/Realtime/server/src/room/template/permission.rs
+++ b/modules/matches/Realtime/server/src/room/template/permission.rs
@@ -102,15 +102,7 @@ impl PermissionManager {
 	fn get_permission_by_group(member_group: AccessGroups, groups: &FnvHashMap<AccessGroups, Permission>) -> Permission {
 		groups
 			.iter()
-			.filter_map(
-				|(group, &permission)| {
-					if group.contains_any(&member_group) {
-						Some(permission)
-					} else {
-						None
-					}
-				},
-			)
+			.filter_map(|(group, &permission)| group.contains_any(&member_group).then_some(permission))
 			.max()
 			.unwrap_or(Permission::Rw)
 	}

--- a/modules/matches/Realtime/server/src/server/manager.rs
+++ b/modules/matches/Realtime/server/src/server/manager.rs
@@ -102,7 +102,7 @@ impl RoomsServerManager {
 	pub fn new(socket: UdpSocket, plugin_names: FnvHashSet<String>) -> Result<Self, RoomsServerManagerError> {
 		let (sender, receiver) = std::sync::mpsc::channel();
 		let halt_signal = Arc::new(AtomicBool::new(false));
-		let cloned_halt_signal = halt_signal.clone();
+		let cloned_halt_signal = Arc::clone(&halt_signal);
 		thread::Builder::new()
 			.name(format!("server({:?})", socket.local_addr()))
 			.spawn(move || match RoomsServer::new(socket, receiver, halt_signal, plugin_names) {
@@ -215,7 +215,7 @@ impl RoomsServerManager {
 	}
 
 	pub(crate) fn get_halt_signal(&self) -> Arc<AtomicBool> {
-		self.halt_signal.clone()
+		Arc::clone(&self.halt_signal)
 	}
 
 	pub fn shutdown(&mut self) {

--- a/modules/matches/Realtime/server/src/server/measurers.rs
+++ b/modules/matches/Realtime/server/src/server/measurers.rs
@@ -139,8 +139,8 @@ impl Measurers {
 					])
 					.const_labels(
 						vec![
-							("command".to_string(), command.to_string()),
-							("field_id".to_string(), format!("{:?}", field_id)),
+							("command".to_owned(), command.to_string()),
+							("field_id".to_owned(), format!("{:?}", field_id)),
 						]
 						.into_iter()
 						.collect(),
@@ -171,7 +171,7 @@ impl Measurers {
 		MeasurersByLabel::new(
 			registry,
 			Box::new(|template| {
-				Opts::new("object_count", "object count").const_labels(vec![("template".to_string(), template.clone())].into_iter().collect())
+				Opts::new("object_count", "object count").const_labels(vec![("template".to_owned(), template.clone())].into_iter().collect())
 			}),
 		)
 	}
@@ -180,7 +180,7 @@ impl Measurers {
 		MeasurersByLabel::new(
 			registry,
 			Box::new(|template| {
-				Opts::new("member_count", "member count").const_labels(vec![("template".to_string(), template.clone())].into_iter().collect())
+				Opts::new("member_count", "member count").const_labels(vec![("template".to_owned(), template.clone())].into_iter().collect())
 			}),
 		)
 	}
@@ -189,7 +189,7 @@ impl Measurers {
 		MeasurersByLabel::new(
 			registry,
 			Box::new(|template| {
-				Opts::new("room_count", "room count").const_labels(vec![("template".to_string(), template.clone())].into_iter().collect())
+				Opts::new("room_count", "room count").const_labels(vec![("template".to_owned(), template.clone())].into_iter().collect())
 			}),
 		)
 	}
@@ -247,20 +247,17 @@ impl Measurers {
 		name: &str,
 		help: &str,
 	) -> Box<LabelFactoryFactory<(Option<FieldType>, Option<FieldId>, heapless::String<50>), Opts>> {
-		let name = name.to_string();
-		let help = help.to_string();
+		let name = name.to_owned();
+		let help = help.to_owned();
 		Box::new(move |(t, id, template)| {
 			Opts::new(name.as_str(), help.as_str()).const_labels(
 				vec![
+					("field_type".to_owned(), t.map(|f| f.to_string()).unwrap_or_else(|| "unknown".to_owned())),
 					(
-						"field_type".to_string(),
-						t.map(|f| f.to_string()).unwrap_or_else(|| "unknown".to_string()),
+						"field_id".to_owned(),
+						id.map(|f| format!("{}", f)).unwrap_or_else(|| "unknown".to_owned()),
 					),
-					(
-						"field_id".to_string(),
-						id.map(|f| format!("{}", f)).unwrap_or_else(|| "unknown".to_string()),
-					),
-					("template".to_string(), template.to_string()),
+					("template".to_owned(), template.to_string()),
 				]
 				.into_iter()
 				.collect(),

--- a/modules/matches/Realtime/server/src/server/mod.rs
+++ b/modules/matches/Realtime/server/src/server/mod.rs
@@ -47,8 +47,8 @@ impl RoomsServer {
 	) -> Result<Self, io::Error> {
 		let measures = Rc::new(RefCell::new(Measurers::new(prometheus::default_registry())));
 		Ok(Self {
-			network_layer: NetworkLayer::new(socket, measures.clone())?,
-			rooms: Rooms::new(measures.clone(), plugin_names.clone()),
+			network_layer: NetworkLayer::new(socket, Rc::clone(&measures))?,
+			rooms: Rooms::new(Rc::clone(&measures), plugin_names.clone()),
 			receiver,
 			halt_signal,
 			time_offset: None,
@@ -106,7 +106,7 @@ impl RoomsServer {
 				.room_by_id
 				.get_mut(&room_id)
 				.map(|room| {
-					room.command_trace_session.clone().borrow_mut().execute_task(task);
+					Rc::clone(&room.command_trace_session).borrow_mut().execute_task(task);
 					ManagementTaskResult::CommandTracerSessionTask
 				})
 				.ok_or(TaskExecutionError::RoomNotFound(RoomNotFoundError(room_id)))?,

--- a/modules/matches/Realtime/server/src/server/network.rs
+++ b/modules/matches/Realtime/server/src/server/network.rs
@@ -29,7 +29,7 @@ struct MemberSession {
 	peer_address: Option<SocketAddr>,
 	private_key: MemberPrivateKey,
 	max_receive_frame_id: FrameId,
-	pub protocol: Protocol,
+	pub(crate) protocol: Protocol,
 }
 
 impl NetworkLayer {
@@ -292,7 +292,7 @@ mod tests {
 		let size = frame.encode(&mut Cipher::new(&member_template.private_key), &mut buffer).unwrap();
 		udp_server.process_in_frame(&mut rooms, &buffer, size, addr_2, Instant::now());
 
-		assert_eq!(udp_server.sessions.get(&member_and_room_id).unwrap().peer_address.unwrap(), addr_1);
+		assert_eq!(udp_server.sessions[&member_and_room_id].peer_address.unwrap(), addr_1);
 	}
 
 	#[test]

--- a/modules/matches/Realtime/server/src/server/rooms.rs
+++ b/modules/matches/Realtime/server/src/server/rooms.rs
@@ -42,7 +42,7 @@ impl Rooms {
 		self.measurers.borrow_mut().on_create_room(&template.name);
 
 		let room_id = self.room_id_generator;
-		let room = Room::new(room_id, template, self.measurers.clone(), self.plugin_names.clone());
+		let room = Room::new(room_id, template, Rc::clone(&self.measurers), self.plugin_names.clone());
 		self.room_by_id.insert(room_id, room);
 		room_id
 	}

--- a/modules/matches/Registry/server/src/proto.rs
+++ b/modules/matches/Registry/server/src/proto.rs
@@ -1,4 +1,13 @@
 pub mod matches {
+	#![allow(
+		clippy::empty_structs_with_brackets,
+		clippy::derive_partial_eq_without_eq,
+		clippy::wildcard_imports,
+		clippy::return_self_not_must_use,
+		clippy::clone_on_ref_ptr,
+		clippy::similar_names
+	)]
+
 	pub mod registry {
 		pub mod internal {
 			tonic::include_proto!("cheetah.matches.registry.internal");

--- a/modules/matches/Registry/server/src/registry/relay_addrs.rs
+++ b/modules/matches/Registry/server/src/registry/relay_addrs.rs
@@ -41,6 +41,7 @@ impl From<Addrs> for RelayAddrs {
 impl TryFrom<Addr> for SocketAddr {
 	type Error = AddrsError;
 
+	#[allow(clippy::map_err_ignore)]
 	fn try_from(a: Addr) -> Result<Self, Self::Error> {
 		let ip = IpAddr::from_str(&a.host).map_err(|_| AddrsError::MalformedAddrs)?;
 		Ok(SocketAddr::new(ip, a.port.try_into().map_err(|_| AddrsError::MalformedAddrs)?))

--- a/modules/matches/Registry/server/src/registry/relay_finder.rs
+++ b/modules/matches/Registry/server/src/registry/relay_finder.rs
@@ -2,20 +2,20 @@ use crate::registry::relay_addrs::Addrs;
 use crate::registry::relay_prober::RelayProber;
 use crate::registry::storage::{Storage, StorageError};
 
-pub struct RelayFinder {
+pub(crate) struct RelayFinder {
 	storage: Box<dyn Storage>,
 	prober: Box<dyn RelayProber>,
 }
 
 impl RelayFinder {
-	pub fn new(storage: Box<dyn Storage>, prober: Box<dyn RelayProber>) -> Self {
+	pub(crate) fn new(storage: Box<dyn Storage>, prober: Box<dyn RelayProber>) -> Self {
 		RelayFinder { storage, prober }
 	}
 
 	/// Получить адрес доступного Relay из хранилища и проверяет что он доступен
 	/// проверка необходима, т.к. в случае падения Registry и Relay одновременно, адрес Relay может остаться в хранилище.
 	/// Если Relay недоступен, удаляем его из хранилища и пробуем получить новый адрес.
-	pub async fn get_random_relay_addr(&self) -> Result<Addrs, StorageError> {
+	pub(crate) async fn get_random_relay_addr(&self) -> Result<Addrs, StorageError> {
 		loop {
 			let addrs = self.storage.get_random_relay_addr().await?;
 			tracing::info!("probing relay {:?}", addrs);

--- a/modules/matches/Registry/server/src/registry/relay_prober.rs
+++ b/modules/matches/Registry/server/src/registry/relay_prober.rs
@@ -11,12 +11,12 @@ use crate::proto::matches::realtime::internal::realtime_client::RealtimeClient;
 use crate::proto::matches::realtime::internal::ProbeRequest;
 
 #[async_trait]
-pub trait RelayProber: Send + Sync {
+pub(crate) trait RelayProber: Send + Sync {
 	async fn probe(&self, addr: SocketAddr) -> Result<(), ProbeError>;
 }
 
 #[derive(Error, Debug)]
-pub enum ProbeError {
+pub(crate) enum ProbeError {
 	#[error(transparent)]
 	TransportError(#[from] tonic::transport::Error),
 
@@ -24,7 +24,7 @@ pub enum ProbeError {
 	GrpcErrorStatus(#[from] tonic::Status),
 }
 
-pub struct ReconnectProber {}
+pub(crate) struct ReconnectProber;
 
 #[async_trait]
 impl RelayProber for ReconnectProber {

--- a/modules/matches/Registry/server/src/registry/storage.rs
+++ b/modules/matches/Registry/server/src/registry/storage.rs
@@ -18,7 +18,7 @@ pub enum StorageError {
 }
 
 #[async_trait]
-pub trait Storage: Send + Sync {
+pub(crate) trait Storage: Send + Sync {
 	async fn get_random_relay_addr(&self) -> Result<Addrs, StorageError>;
 	async fn update_status(&self, addrs: &Addrs, state: RelayState) -> Result<(), StorageError>;
 	async fn remove_relay(&self, addrs: &Addrs) -> Result<(), StorageError>;
@@ -28,7 +28,7 @@ const REDIS_SET_KEY_READY: &str = "registry:relay-addrs:ready";
 const REDIS_SET_KEY_ALLOCATED: &str = "registry:relay-addrs:allocated";
 
 #[derive(Clone)]
-pub struct RedisStorage {
+pub(crate) struct RedisStorage {
 	conn: MultiplexedConnection,
 }
 
@@ -78,7 +78,7 @@ impl RedisStorage {
 	/// Создать новый `RedisStorage`
 	/// `RedisStorage` использует multiplexed соединение к Redis
 	/// `RedisStorage` можно клонировать
-	pub async fn new(dsn: &str) -> Result<Self, StorageError> {
+	pub(crate) async fn new(dsn: &str) -> Result<Self, StorageError> {
 		tracing::info!("connecting to redis: {:?}", dsn);
 		let client = redis::Client::open(dsn)?;
 		client
@@ -122,7 +122,7 @@ impl RedisStorage {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
 	use crate::proto::matches::registry::internal::RelayState;
 	use crate::registry::relay_addrs::Addrs;
 	use crate::registry::storage::{RedisStorage, Storage, StorageError};


### PR DESCRIPTION
добавил линтеры из clippy::restriction и линтеры rustc, невключенные в другие группы.

линтеры с todo комментарием в allow секции стоит починить, но там или много изменений, или нужно немного вникать в код.
Линтеры без todo коммента посчитал бесполезными для проекта.

Основные изменения
* &str.to_owned() вместо to_string()
* явный Arc::clone(&val) вместо val.clone() 
* (a > b).then(|| val) вместо if { Some(val) } else { None }
* ну и pub(crate) конечно

Если все выглядит ок, то сделаю squash перед мержем.